### PR TITLE
fix doc build error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ matplotlib
 Sphinx
 javasphinx
 sphinx_rtd_theme
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex==1.0.0


### PR DESCRIPTION
nnabla-nas document builder fails due to sphinx version mismatch, so fix the sphinx version.