### PR TITLE
latency measurements and exporter functions to nnp and onnx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,11 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#NNP - ONNX
+*.onnx
+*.nnp
+*.lat
+graph
+graph.pdf
+examples/*

--- a/docs/source/features/estimator.rst
+++ b/docs/source/features/estimator.rst
@@ -1,7 +1,10 @@
 Estimating the Latency of DNN Architectures
 -------------------------------------------
 
-Hardware aware NAS addresses the problem, how to fit the architecture of DNNs to specific target devices, such that they fulfill given performance requirements. This is, for example, important if we want to deploy DNN based algorithms to mobile devices. Naturally, we want to find DNN architectures that run fast and require only little memory. More specifically, we might be interested in DNNs that have
+Hardware aware NAS addresses the problem, how to fit the architecture of DNNs to specific target devices,
+such that they fulfill given performance requirements. This is, for example, important if we want to deploy
+DNN based algorithms to mobile devices. Naturally, we want to find DNN architectures that run fast and require 
+only little memory. More specifically, we might be interested in DNNs that have
 
 - a low latency.
 - a small parameter memory footprint.
@@ -9,16 +12,18 @@ Hardware aware NAS addresses the problem, how to fit the architecture of DNNs to
 - a high throughput.
 - a low power consumption.
 
-To perform hardware aware NAS, we, therefore, need tools to estimate such performance measures on target devices. The module nnabla_nas.utils.estimator implements
-such tools, i.e., it provides methods to
-estimate the latency and the memory footprint of DNN architectures.
+To perform hardware aware NAS, we, therefore, need tools to estimate such performance measures on target devices. 
+The modules inside nnabla_nas.utils.estimator.latency implement
+such tools, i.e., they provide methods to estimate the latency and the memory footprint 
+of DNN architectures. 
 
 
 
 How to estimate the latency of DNN architectures
 ................................................
 
-There are different ways how to estimate the latency of a DNN architecture on the device. Two naive ways how to do it are given in the figure below, namely
+There are different ways how to estimate the latency of a DNN architecture on the device. 
+Two naive ways how to do it are given in the figure below, namely
 
 - network-based estimation
 - layer-based estimation
@@ -26,47 +31,110 @@ There are different ways how to estimate the latency of a DNN architecture on th
 .. image:: images/measurement.png
 
 Here, z is a random vector which encodes the structure of the network.
-A network-based latency estimator instantiates and measures the time it takes to calculate the output of the computational graph at once. We call the resulting latency the true latency. A layer-based estimator instantiates the computational graph and estimates the latency of each layer separately. The latency of the whole network is calculated as the sum of all the individual layer latencies. We call this the accumulated latency. Because the individual calculation of each layer causes some computational overhead, the layer-based latency estimate is not the same as the true latency. However, experiments show that the differences between the true and the accumulated latency estimates are small, meaning that both can be used for hardware aware NAS.
+A network-based latency estimator instantiates and measures the time it takes to calculate
+the output of the computational graph at once. We call the resulting latency the true latency.
+A layer-based estimator instantiates the computational graph and estimates the latency of 
+each layer separately. The latency of the whole network is calculated as the sum of all the
+latencies from the individual layers. We call this the accumulated latency. Because the individual
+calculation of each layer causes some computational overhead, the layer-based latency estimate
+is not the same as the true latency. However, experiments show that the differences between
+the true and the accumulated latency estimates are small, meaning that both can be used for hardware aware NAS.
 
-In the NNabla NAS framework, we only implement layer-based latency estimators. The reason for this is, that we want the estimators to run offline, i.e., before the architecture search. Depending on the target hardware, a latency measurement on a device can take considerable time. Therefore, latency measurements during architecture search are
-not desirable. With network-based estimators, the number of networks to measure grows exponentially with the number of layers and the number of candidates per layer. However, with the layer-based approach, the growth is only linear.
+In the NNabla NAS framework, we only implemented layer-based latency estimators:
 
+- *nnabla_nas.utils.estimator.latency.LatencyEstimator*: a layer-based estimator that extracts the layers of the network based on the active modules contained in the network
+- *nnabla_nas.utils.estimator.latency.LatencyGraphEstimator*: a layer-based estimator that extracts the layers of the network based on the NNabla graph of the network
+
+The reason for this is that we want the estimators to run offline, i.e., before the architecture search.
+Depending on the target hardware, a latency measurement on a device can take considerable time. Therefore,
+latency measurements during architecture search are not desirable. 
+With network-based estimators, the number of networks to measure grows exponentially with the number of 
+layers and the number of candidates per layer. However, with the layer-based approach, the growth is only linear.
+
+However, you can try and use the network-based latency estimator from NNabla, which we make available at 
+*nnabla_nas.utils.estimator.latency.Profiler*
 
 
 How to use the estimators
 .........................
 
-The following example shows how to use an estimator. First, we instantiate the model we want to estimate the latency of. To this end, we borrow the implementation of the MobileNet from :ref:`mobilenet`. If the network is constructed from dynamic modules, the NNabla graph must be constructed once, such that each module knows its input shapes. We can then feed the model to the estimator to calculate the latency. Please note, the estimator always assumes a batch size of one. Further, the model will always be profiled with the input shapes that have been calculated when the last NNabla graph was created.
+The following example shows how to use an estimator. First, we instantiate the model we want to estimate the latency of. 
+To this end, in this example, we borrow the implementation of the MobileNet from :ref:`mobilenet`. If the network
+is constructed from dynamic modules (as in this case), the NNabla graph must be constructed once, such that each
+module knows its input shapes. We can then feed the model to the estimator to calculate the latency. Please note that
+the estimator always assumes a batch size of one. Further, the model will always be profiled with the input shapes 
+that have been calculated when the last NNabla graph was created.
 
 .. code-block:: python
 
-    from nnabla_nas.contrib.mobilenet import TrainNet
-    from nnabla_nas.utils.estimator import LatencyEstimator
+    from nnabla_nas.contrib.classification.mobilenet import SearchNet
+    from nnabla_nas.utils.estimator.latency import LatencyGraphEstimator, LatencyEstimator
     import nnabla as nn
     from nnabla.ext_utils import get_extension_context
 
-    cuda_device_id = 0
-    ctx = get_extension_context('cudnn', device_id=cuda_device_id)
+    # Parameters for the Latency Estimation
+    outlier = 0.05
+    max_measure_execution_time = 500
+    time_scale = "m"
+    n_warmup = 10
+    n_runs = 100
+    device_id = 0
+    ext_name='cudnn'
+
+    ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
     nn.set_default_context(ctx)
 
+    layer_based_estim_by_module = LatencyEstimator(
+        device_id=device_id, ext_name=ext_name, outlier=outlier, time_scale=time_scale, n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,n_run=n_runs
+        )
+
+    layer_based_estim_by_graph = LatencyGraphEstimator(
+        device_id=device_id, ext_name=ext_name, outlier=outlier, time_scale=time_scale, n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,n_run=n_runs
+        )
+
+    # create the network
+    net = SearchNet()
+
+    # For *dynamic graphs* like MobileNetV2, we need to create the nnabla graph once 
+    # This defines the input shapes of all modules
     inp = nn.Variable((1,3,32,32))
-    net = TrainNet()
-    #create the nnabla graph once (this defines the input shapes of all modules)
     out = net(inp)
 
-    est = LatencyEstimator()
-    latency = est.get_estimation(net)
+    layer_based_latency_by_m = layer_based_estim_by_module.get_estimation(net)
+    layer_based_latency_by_g = layer_based_estim_by_graph.get_estimation(out)
 
+The two results differ just because the estimation is carried out two separate times,
+for each different layer found. Conceptually, both estimations should be identical.
 
-Please note, if the candidate space contains zero modules, the estimate can deviate considerably
-if the model is constructed from dynamic modules. To make this clearer, we continue the
-code example from above.
+Please note: if the candidate space contains zero modules, the estimate can deviate considerably
+if the model is constructed from *dynamic* modules. To make this clearer, we continue the code example from above:
 
 .. code-block:: python
 
-    inp = nn.Variable((1,3,128,128))
-    out2 = net(inp)
-    latency2 = est.get_estimation(net)
+    inp2 = nn.Variable((1,3,1024,1024))
+    out2 = net(inp2)
+    layer_based_latency_by_m2 = layer_based_estim_by_module.get_estimation(net)
+    layer_based_latency_by_g2 = layer_based_estim_by_graph.get_estimation(out2)
 
-Because we constructed a second NNabla graph (out2) that has a much larger input, the input shapes of all modules in the network will be changed accordingly. Therefore, latency2 will be much larger than the previously measured latency. Profiling static graphs are similar.
-The only difference is, that the input shapes of static modules cannot change after instantiation, meaning that we do not need to construct an NNabla graph before latency estimation.
+Because we constructed a second NNabla graph (out2) that has a much larger input, the input shapes of all modules
+in the network will be changed accordingly. Therefore, these later latencies will be much larger than the previously
+measured latencies. 
+
+Profiling *static* graphs is similar. The only difference is that the input shapes of
+static modules cannot change after instantiation, meaning that we do not need to construct the NNabla 
+graph before latency estimation.
+
+
+As a further example, you can also use the network-based estimator (Profiler) by continuing the code above:
+
+.. code-block:: python
+
+    from nnabla_nas.utils.estimator.latency import Profiler
+    network_based_estim = Profiler(out2,
+        device_id=device_id, ext_name=ext_name, outlier=outlier, time_scale=time_scale, n_warmup=n_warmup, 
+        max_measure_execution_time=max_measure_execution_time,n_run=n_runs
+    )
+    network_based_estim.run()
+    net_based_latency = float(network_based_estim.result['forward_all'])

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ NNablaNAS is a Python package that provides methods in neural architecture searc
 
 - Searcher algorithms to learn the architecture and model parameters (e.g., *DartsSearcher* and *ProxylessNasSearcher*)
 
-- Regularizers (e.g., *LatencyEstimator* and *MemoryEstimator*) which can be used to enforce hardware constraints
+- Regularizers (e.g., *LatencyGraphEstimator* and *MemoryEstimator*) which can be used to enforce hardware constraints
 
 In this document, we will describe how to use the Python APIs, some examples, and the contribution guideline for developers. The latest release version can be installed from  `here <https://github.com/sony/nnabla-nas>`_.
 

--- a/docs/source/tutorials/static_module_construct.rst
+++ b/docs/source/tutorials/static_module_construct.rst
@@ -18,12 +18,10 @@ that defines a simple d layer CNN:
 
    from nnabla_nas import module as Mo
    import nnabla as nn
-
    inp = nn.Variable((10, 3, 32, 32))
-
    def net(x, d=10):
-      c_inp = Mo.Conv(3, 64, (32,32))
-      c_l = [Mo.Conv(64, 64, (32,32)) for i in range(d-1)]
+      c_inp = Mo.Conv(3, 64, (3,3))
+      c_l = [Mo.Conv(64, 64, (3,3)) for i in range(d-1)]
       x = c_inp(x)
 
       for i in range(d-1):
@@ -32,7 +30,7 @@ that defines a simple d layer CNN:
 
    out = net(inp)
 
-The network consists of 3 convolutional layers, with a 3x3 kernel. Each layer
+The network consists of 10 convolutional layers, with a 3x3 kernel. Each layer
 computes 64 feature maps. Following the dynamic graph paradigm,
 the structure of the network is only defined in the code, i.e., it is only defined
 by the sequence in which we apply the layers c_l. The modules themselves are agnostic to
@@ -49,16 +47,18 @@ The example network from the example above can, for example, be defined as:
 
 .. code-block:: python
 
-   from nnabla_nas.module import static_module as Smo
+   from nnabla_nas.module import static as Smo
    import nnabla as nn
-
+   
+   inp = nn.Variable((10, 3, 32, 32))
+   
    def net(x, d=10):
       modules = [Smo.Input(nn.Variable((10, 3, 32, 32)))]
-      for i in range(d):
-         modules.append(Smo.Conv(parents=[modules[-1]], modules[-1].shape[1], 64, (32,32)))
+      for i in range(d-1):
+         modules.append(Smo.Conv(parents=[modules[-1]], in_channels=modules[-1].shape[1], out_channels=64, kernel=(3,3)))
       return modules[-1]
-
-   out = net()
+   
+   out = net(inp)
 
 In comparison to dynamic modules, each static module keeps a list of its parents. Therefore, the graph structure is stored within and can later be retrieved from the modules. Furthermore, static_modules introduce a sort of shape security, i.e., once a module is instantiated, the input and output shape of the module are fixed and cannot be changed anymore.
 
@@ -76,45 +76,49 @@ while others are dropped. For an efficient search, it is desirable to have simpl
 graph optimization algorithms in place, i.e., algorithms that optimize the computational
 graph of the selected subnetworks before executing them.
 
-Consider for example the following search space: 1) The network applies an input convolution (conv 1). 2) Two candidate
-layers are applied to the output of conv 1, that are a zero operation and another convolution (conv 2). 3) The Join layer
-randomly selects the output of one of the candidate layers and feeds it to conv 3. If Join selects Conv 2, we need to calculate
-the output of Conv 1, Conv 2 and Conv 3. However, if Join selects Zero, only the output of Conv 3 must be calculated, because
-selecting Zero, effectively cuts the computational graph, meaning that all layers that are the parent of Zero and that have
-no shortcut connection to any following layer can be deleted from the computational graph. Static modules implement such graph optimization, meaning that they can speed up computations.
+Consider for example the following search space: 
+   - The network applies an input convolution (conv 1). 
+   - Two candidate layers are applied to the output of conv 1: a zero operation and another convolution (conv 2). 
+   - The Join layer randomly selects the output of one of the candidate layers and feeds it to (conv 3). 
+   
+If Join selects Conv 2, we need to calculate the output of Conv 1, Conv 2 and Conv 3. However, if Join selects Zero, only the output of Conv 3 must be calculated, because
+selecting Zero, effectively cuts the computational graph, meaning that all layers that are parents of Zero and that have no shortcut connection to any following layers can be deleted from the computational graph. 
+
+Static modules implement such graph optimization, meaning that they can speed up computations.
 
 .. image:: ../images/static_example_graph.png
 
 A second reason why a static graph definition is a natural choice for hardware aware NAS is related to latency modeling.
-To perform hardware aware NAS, we need to estimate the latency of the subnetworks that have been
+In order to perform hardware aware NAS, we need to estimate the latency of the subnetworks that have been
 drawn from the candidate space in order to decide whether the network meets our latency requirements or not.
 Typically, the latency of all layers (modules) within the search space are measured once individually. The latency of a
-subnetwork of the search space, then, is a function of those individual latencies and of the structure of the subnetwork. Note,
-simply summing up all the latencies of the modules that are contained in the subnetwork is wrong. This is obvious if we reconsider the
-example from above. All the modules Conv 1 to Conv 3 have a latency > 0, while Zero and Join have a latency of 0. If Join selects Zero,
-Conv 1, Zero, Join and Conv 3 are part of the subnetwork. However, summing up the latency of Conv 1,
-Zero, Join and Conv 3 are wrong. The correct latency would be if we only consider Conv 3.
+subnetwork of the search space, then, is a function of those individual latencies and of the structure of the subnetwork. 
+Simply summing up all the latencies of the modules that are contained in the subnetwork is wrong. 
+
+This is obvious if we reconsider the example from above. All the modules Conv 1 to Conv 3 have a latency > 0, while Zero and Join have a latency of 0. If Join selects Zero,
+Conv 1, Zero, Join and Conv 3 are part of the subnetwork. However, summing up the latency of Conv 1, Zero, Join and Conv 3 are wrong. The correct latency would be calculated if we only consider Conv 3.
 
 Other problems which need knowledge of the graph structure are for example:
-1) Graph similarity calculation
-2) NAS, using Bayesian optimization algorithms
-3) Modeling the memory footprint of DNNs (activation memory)
+   - Graph similarity calculation
+   - NAS, using Bayesian optimization algorithms
+   - Modeling the memory footprint of DNNs (activation memory)
 
 Which modules are currently implemented?
 ........................................
 
-There is a static version of all dynamic modules implemented in nnabla_nas.modules. There are currently two static search spaces,
-namely contrib.zoph and the contrib.random_wired.
+There is a static version of all dynamic modules implemented in nnabla_nas.modules. There are currently two static search spaces,  namely contrib.zoph and  contrib.random_wired.
 
 Implementing new static modules
 ...............................
 
 There are different ways of how to define static modules. 
 
-- You can derive a static version from a dynamic module. Consider the following
+You can derive a static version from a dynamic module. Consider the following
 example, where we want to derive a static Conv module from the dynamic Conv module.
-First, we derive our StaticConv module from A) The dynamic Conv class, B) The StaticModule base class. 
-We call the __init__() of both parent classes. Please note, that the order of inheritance is important.
+First, we derive our StaticConv module from
+   - The dynamic Conv class
+   - The StaticModule base class
+We call the __init__() of both parent classes. Please note that the order of inheritance is important !
 
 .. code-block:: python
 
@@ -128,8 +132,9 @@ We call the __init__() of both parent classes. Please note, that the order of in
             if len(self._parents) > 1:
                 raise RuntimeError
 
-- We can also implement a new static module from scratch, implementing the call method. Please follow the same steps that are documented in the dynamic module tutorial. In the following example, we define a StaticConv, implementing
-the call method. You can either use the NNabla API or dynamic modules to define the transfer function. In our case, we use dynamic modules.
+We can also implement a new static module from scratch, implementing the call method. Please follow the same steps that are documented in the dynamic module tutorial. 
+
+In the following example, we define a StaticConv, implementing the call method. You can either use the NNabla API or dynamic modules to define the transfer function. In our case, we use dynamic modules.
 
 .. code-block:: python
 

--- a/examples/classification/calc_latency.py
+++ b/examples/classification/calc_latency.py
@@ -1,0 +1,65 @@
+import nnabla as nn
+from nnabla_nas.contrib.classification.zoph import SearchNet as Zoph
+from nnabla_nas.contrib.classification.random_wired import TrainNet as Rdw
+from nnabla_nas.contrib.classification.mobilenet import SearchNet as MobileNet
+
+from nnabla_nas.utils.estimator.latency import LatencyGraphEstimator, Profiler
+from nnabla.ext_utils import get_extension_context
+
+all_networks = {'zoph': Zoph, 'randomly_wired': Rdw, 'mobilenet_v2': MobileNet}
+
+# Which example network to run? OPTIONS:
+# 'zoph': a ZOPH network
+# 'randomly_wired': a RANDOM WIRED network
+# 'mobilenet_v2': a MOBILENETv2 network
+network_to_run = 'mobilenet_v2'
+print(' ** Running example for ' + network_to_run + ' network **')
+
+# Where to run the latency estimation ?
+ext_name = 'cudnn'  # OPTIONS: 'cpu', 'cuda', 'cudnn'
+device_id = 0
+ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+nn.set_default_context(ctx)
+
+# Params for the latency estimation
+max_measure_execution_time = 500
+time_scale = "m"
+n_warmup = 10
+n_run = 100
+# Portion of outliers which will be removed from the statistical results
+outlier = 0.05
+
+model = all_networks[network_to_run]()
+out = model(nn.Variable((1, 3, 32, 32)))
+
+for i in range(10):
+    estimator = LatencyGraphEstimator(
+        device_id=device_id, ext_name=ext_name,
+        outlier=outlier,
+        time_scale=time_scale,
+        n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,
+        n_run=n_run
+    )
+
+    runner = Profiler(
+        out,
+        device_id=device_id, ext_name=ext_name,
+        outlier=outlier,
+        time_scale=time_scale,
+        n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,
+        n_run=n_run
+    )
+
+    print('- running LatencyGraphEstimator ...')
+    lat2 = estimator.get_estimation(out)
+
+    print('- running Profiler ...')
+    runner.run()
+    latency = float(runner.result['forward_all'])
+
+    print(f'X-> run={i}\t real_latency(Profiler)=' +
+          f'{latency:.5f}ms\t accum_latency(LatencyGraphEstimation)=' +
+          f'{lat2:.5f}ms\t n_functions={len(estimator._visitor._functions)}'
+          )

--- a/examples/classification/calc_latency_export_onnx.py
+++ b/examples/classification/calc_latency_export_onnx.py
@@ -1,0 +1,895 @@
+import sys
+import os
+import nnabla as nn
+import glob
+from nnabla.ext_utils import get_extension_context
+
+# Global params for the latency estimation
+outlier = 0.05
+max_measure_execution_time = 500
+time_scale = "m"
+n_warmup = 10
+n_runs = 100
+
+
+def get_active_and_profiled_modules(zn):
+    print('\n**START PRINT ******************************')
+    list = []
+    for mi in zn.get_net_modules(active_only=True):
+        if type(mi) in zn.modules_to_profile:
+            if type(mi) not in list:
+                print(type(mi))
+                list.append(type(mi))
+    print('**END PRINT ******************************\n')
+    return list
+
+
+def estim_fwd(output, n_run=100):
+    import time
+    # warm up
+    output.forward()
+    result = 0.0
+    # start_0 = time.time()
+    for j in range(n_run):
+        start = time.time()
+        output.forward()
+        stop = time.time()
+        result += stop - start
+
+    return result / n_run
+
+
+def init_calc_latency(output, ext_name='cpu', device_id=0):
+    from nnabla_nas.utils.estimator.latency import LatencyEstimator
+    from nnabla_nas.utils.estimator.latency import LatencyGraphEstimator
+    from nnabla_nas.utils.estimator.latency import Profiler
+
+    # This is the old LatencyEstimator used for layers: by modules
+    # This is deprecated. You should use the estimator by graph
+    estim_accum_by_mod = LatencyEstimator(
+        device_id=device_id, ext_name=ext_name,
+        outlier=outlier,
+        time_scale=time_scale,
+        n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,
+        n_run=n_runs
+    )
+
+    # This is the new LatencyEstimator used for layers: by graph
+    estim_accum_by_graph = LatencyGraphEstimator(
+        device_id=device_id, ext_name=ext_name,
+        outlier=outlier,
+        time_scale=time_scale,
+        n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,
+        n_run=n_runs
+    )
+
+    # This is the LatencyEstimator used for the whole net, by graph
+    estim_net = Profiler(
+        output,
+        device_id=device_id, ext_name=ext_name,
+        outlier=outlier,
+        time_scale=time_scale,
+        n_warmup=n_warmup,
+        max_measure_execution_time=max_measure_execution_time,
+        n_run=n_runs
+    )
+    return estim_net, estim_accum_by_graph, estim_accum_by_mod
+
+
+def calc_latency_and_onnx(exp_nr, calc_latency=False, ext_name='cpu',
+                          device_id=0, onnx=False):
+
+    nn.clear_parameters()
+    N = 10  # number of random networks to sample
+    estim_net = None
+    estim_accum_by_graph = None
+    estim_accum_by_mod = None
+
+    #  10 **************************
+    if exp_nr == 10:
+        from nnabla_nas.contrib import zoph
+
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        OUTPUT_DIR = './logs/zoph/one_net/'
+
+        # Sample one ZOPH network from the search space
+        shape = (1, 3, 32, 32)
+        input = nn.Variable(shape)
+        zn = zoph.SearchNet()
+        zn.apply(training=False)
+        output = zn(input)
+
+        estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+            init_calc_latency(output, ext_name=ext_name, device_id=device_id)
+
+        # zn_unique_active_modules = get_active_and_profiled_modules(zn)
+
+        # SAVE GRAPH in PDF
+        zn.save_graph(OUTPUT_DIR + 'zn')
+        # SAVE WHOLE NET. Calc whole net (real) latency using [Profiler]
+        # Calculate also layer-based latency
+        # The modules are discovered using the nnabla graph of the whole net
+        # The latency is then calculated based on each individual module's
+        # nnabla graph [LatencyGraphEstimator]
+        net_lat, acc_lat = zn.save_net_nnp(
+                            OUTPUT_DIR + 'zn', input, output,
+                            calc_latency=calc_latency,
+                            func_real_latency=estim_net,
+                            func_accum_latency=estim_accum_by_graph
+                            )
+
+        # reset estim_accum_by_graph
+        estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+            init_calc_latency(output, ext_name=ext_name, device_id=device_id)
+
+        # SAVE ALL MODULES. Calc layer-based latency.
+        # The modules are discovered by going over the module list.
+        # The latency is then calculated based on each individual module's
+        # nnabla graph [LatencyGraphEstimator]
+        acc_lat_g = zn.save_modules_nnp(
+                            OUTPUT_DIR + 'zn_by_graph',
+                            active_only=True,
+                            calc_latency=calc_latency,
+                            func_latency=estim_accum_by_graph
+                            )
+
+        # SAVE ALL MODULES. Calc layer-based latency.
+        # The modules are discovered by going over the module list.
+        # The latency is then calculated using the module [LatencyEstimator]
+        # **** This function is deprecated ****
+        acc_lat_m = zn.save_modules_nnp_by_mod(
+                            OUTPUT_DIR + 'zn_by_module',
+                            active_only=True,
+                            calc_latency=calc_latency,
+                            func_latency=estim_accum_by_mod
+                            )
+
+        # reset estim_accum_by_graph, estim_accum_by_mod
+        estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+            init_calc_latency(output, ext_name=ext_name, device_id=device_id)
+
+        # Just obtain the latencies of all modules without saving files
+        # By graph
+        latencies_1, acc_lat_1 = zn.get_latency(estim_accum_by_graph)
+        # By module (deprecated)
+        latencies_2, acc_lat_2 = zn.get_latency_by_mod(estim_accum_by_mod)
+
+        print(net_lat, acc_lat, acc_lat_g, acc_lat_m, acc_lat_1, acc_lat_2)
+
+        # CONVERT ALL TO ONNX
+        if onnx:
+            zn.convert_npp_to_onnx(OUTPUT_DIR)
+
+        # VERBOSITY - INFO OF NETWORK CONTENT
+        # with open(OUTPUT_DIR + 'zn.txt', 'w') as f:
+        #    print_me(zn, f)
+
+    #  11 **************************
+    if exp_nr == 11:
+        from nnabla_nas.contrib import zoph
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        OUTPUT_DIR = './logs/zoph/many_different_nets/'
+
+        shape = (1, 3, 32, 32)
+        input = nn.Variable(shape)
+
+        # Sample N zoph networks from the search space
+        for i in range(0, N):
+            nn.clear_parameters()
+            zn = zoph.SearchNet()
+            zn.apply(training=False)
+            output = zn(input)
+            if calc_latency:
+                estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                    init_calc_latency(output,
+                                      ext_name=ext_name,
+                                      device_id=device_id
+                                      )
+
+            zn.save_graph(OUTPUT_DIR + 'zn' + str(i))
+            zn.save_net_nnp(OUTPUT_DIR + 'zn' + str(i), input, output,
+                            calc_latency=calc_latency,
+                            func_real_latency=estim_net,
+                            func_accum_latency=estim_accum_by_graph
+                            )
+            zn.save_modules_nnp(OUTPUT_DIR + 'zn' + str(i), active_only=True,
+                                calc_latency=calc_latency,
+                                func_latency=estim_accum_by_graph
+                                )
+        if onnx:
+            zn = zoph.SearchNet()
+            zn.convert_npp_to_onnx(OUTPUT_DIR, opset='opset_snpe')
+
+    #  12 **************************
+    if exp_nr == 12:
+        from nnabla_nas.contrib import zoph
+        import time
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        OUTPUT_DIR = './logs/zoph/same_net_many_times/'
+
+        shape = (1, 3, 32, 32)
+        input = nn.Variable(shape)
+        zn = zoph.SearchNet()
+        zn.apply(training=False)
+        output = zn(input)
+
+        # Measure add-hoc latency of zoph network
+        for i in range(0, N):
+            n_run = 100
+            # warm up
+            output.forward()
+
+            result = 0.0
+            for i in range(n_run):
+                start = time.time()
+                output.forward()
+                stop = time.time()
+                result += stop - start
+
+            mean_time = result / n_run
+            print(mean_time*1000)
+
+        # Measure latency on same zoph network N times
+        for i in range(0, N):
+            if calc_latency:
+                estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                    init_calc_latency(output,
+                                      ext_name=ext_name,
+                                      device_id=device_id
+                                      )
+            zn.save_net_nnp(OUTPUT_DIR + 'zn' + str(i), input, output,
+                            calc_latency=calc_latency,
+                            func_real_latency=estim_net,
+                            func_accum_latency=estim_accum_by_graph
+                            )
+            zn.save_modules_nnp(OUTPUT_DIR + 'zn' + str(i), active_only=True,
+                                calc_latency=calc_latency,
+                                func_latency=estim_accum_by_graph
+                                )
+        zn.save_graph(OUTPUT_DIR)
+        if onnx:
+            zn.convert_npp_to_onnx(OUTPUT_DIR)
+
+    #  20 **************************
+    if exp_nr == 20:
+        from nnabla_nas.contrib import random_wired
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        OUTPUT_DIR = './logs/rdn/one_net/'
+
+        # Sample one random wired network from the search space
+        shape = (1, 3, 32, 32)
+        input = nn.Variable(shape)
+        rw = random_wired.TrainNet()
+        rw.apply(training=False)
+        output = rw(input)
+
+        if calc_latency:
+            estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                init_calc_latency(output,
+                                  ext_name=ext_name,
+                                  device_id=device_id
+                                  )
+
+        rw.save_graph(OUTPUT_DIR + 'rw')
+        rw.save_net_nnp(OUTPUT_DIR + 'rw', input, output,
+                        calc_latency=calc_latency,
+                        func_real_latency=estim_net,
+                        func_accum_latency=estim_accum_by_graph
+                        )
+        rw.save_modules_nnp(OUTPUT_DIR + 'rw', active_only=True,
+                            calc_latency=calc_latency,
+                            func_latency=estim_accum_by_graph
+                            )
+
+        if onnx:
+            rw.convert_npp_to_onnx(OUTPUT_DIR)
+
+    #  21 **************************
+    if exp_nr == 21:
+        from nnabla_nas.contrib import random_wired
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        OUTPUT_DIR = './logs/rdn/many_different_nets/'
+
+        shape = (1, 3, 32, 32)
+        input = nn.Variable(shape)
+
+        # Measure latency on same rdn network N times
+        for i in range(0, N):
+            nn.clear_parameters()
+            rw = random_wired.TrainNet()
+            rw.apply(training=False)
+            output = rw(input)
+
+            if calc_latency:
+                estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                    init_calc_latency(output,
+                                      ext_name=ext_name,
+                                      device_id=device_id
+                                      )
+            rw.save_graph(OUTPUT_DIR + 'rw' + str(i))
+            rw.save_net_nnp(OUTPUT_DIR + 'rw' + str(i), input, output,
+                            calc_latency=calc_latency,
+                            func_real_latency=estim_net,
+                            func_accum_latency=estim_accum_by_graph
+                            )
+            rw.save_modules_nnp(OUTPUT_DIR + 'rw' + str(i), active_only=True,
+                                calc_latency=calc_latency,
+                                func_latency=estim_accum_by_graph
+                                )
+
+        if onnx:
+            rw = random_wired.TrainNet()
+            rw.convert_npp_to_onnx(OUTPUT_DIR, opset='opset_snpe')
+
+    #  22 **************************
+    if exp_nr == 22:
+        from nnabla_nas.contrib import random_wired
+        import time
+
+        OUTPUT_DIR = './logs/rdn/same_net_many_times/'
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        shape = (1, 3, 32, 32)
+        input = nn.Variable(shape)
+        rw = random_wired.TrainNet()
+        rw.apply(training=False)
+        output = rw(input)
+
+        for i in range(0, N):
+            n_run = 10
+            # warm up
+            output.forward()
+
+            result = 0.0
+            for i in range(n_run):
+                start = time.time()
+                output.forward()
+                stop = time.time()
+                result += stop - start
+            mean_time = result / n_run
+            print(mean_time*1000)
+
+        # Measure latency on same rdn network N times
+        for i in range(0, N):
+            if calc_latency:
+                estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                    init_calc_latency(output,
+                                      ext_name=ext_name,
+                                      device_id=device_id
+                                      )
+            rw.save_net_nnp(OUTPUT_DIR + 'rw' + str(i), input, output,
+                            calc_latency=calc_latency,
+                            func_real_latency=estim_net,
+                            func_accum_latency=estim_accum_by_graph
+                            )
+            rw.save_modules_nnp(OUTPUT_DIR + 'rw' + str(i), active_only=True,
+                                calc_latency=calc_latency,
+                                func_latency=estim_accum_by_graph
+                                )
+        rw.save_graph(OUTPUT_DIR + 'rw' + str(i))
+
+        if onnx:
+            rw.convert_npp_to_onnx(OUTPUT_DIR)
+
+    #  31 **************************
+    if exp_nr == 31:
+        from nnabla_nas.contrib.classification.mobilenet import SearchNet
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        OUTPUT_DIR = './logs/mobilenet/many_different_nets/'
+
+        input = nn.Variable((1, 3, 224, 224))
+
+        # number of random networks to sample
+        # Sample N networks from the search space
+        for i in range(0, N):
+            nn.clear_parameters()
+            mobile_net = SearchNet(num_classes=1000)
+            mobile_net.apply(training=False)
+            output = mobile_net(input)
+
+            if calc_latency:
+                estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                    init_calc_latency(output,
+                                      ext_name=ext_name,
+                                      device_id=device_id
+                                      )
+            # This calculates the actual latency of the network
+            # and the accum. latency by adding the latencies of
+            # each module, following the nnabla graph
+            mobile_net.save_net_nnp(OUTPUT_DIR + 'mn' + str(i), input, output,
+                                    calc_latency=calc_latency,
+                                    func_real_latency=estim_net,
+                                    func_accum_latency=estim_accum_by_graph
+                                    )
+
+            """
+            # This calculates the latency of each module going
+            # over the nnabla graph (deprecated)
+            mobile_net.calc_latency_all_modules(
+                    OUTPUT_DIR + 'graph_mn' + str(i), output,
+                    func_latency=estim_accum_by_graph)
+            """
+            # This calculates the latency of each module going
+            # the tree of the modules
+            mobile_net.save_modules_nnp(
+                            OUTPUT_DIR + 'mn' + str(i),  active_only=True,
+                            calc_latency=calc_latency,
+                            func_latency=estim_accum_by_graph
+                            )
+        if onnx:
+            mobile_net = SearchNet()
+            mobile_net.convert_npp_to_onnx(OUTPUT_DIR, opset='opset_snpe')
+
+    #  32 **************************
+    if exp_nr == 32:
+        from nnabla_nas.contrib.classification.mobilenet import SearchNet
+        import time
+
+        OUTPUT_DIR = './logs/mobilenet/same_net_many_times/'
+        ctx = get_extension_context(ext_name=ext_name, device_id=device_id)
+        nn.set_default_context(ctx)
+
+        input = nn.Variable((1, 3, 224, 224))
+        mobile_net = SearchNet(num_classes=1000)
+        mobile_net.apply(training=False)
+        output = mobile_net(input)
+
+        for i in range(0, N):
+            n_run = 100
+            # warm up
+            output.forward()
+
+            result = 0.0
+            for i in range(n_run):
+                start = time.time()
+                output.forward()
+                stop = time.time()
+                result += stop - start
+
+            mean_time = result / n_run
+            print(mean_time*1000)
+
+        # Measure latency on same network N times
+        for i in range(0, N):
+            if calc_latency:
+                estim_net, estim_accum_by_graph, estim_accum_by_mod = \
+                    init_calc_latency(output,
+                                      ext_name=ext_name,
+                                      device_id=device_id
+                                      )
+
+            mobile_net.save_net_nnp(OUTPUT_DIR + 'mn' + str(i), input, output,
+                                    calc_latency=calc_latency,
+                                    func_real_latency=estim_net,
+                                    func_accum_latency=estim_accum_by_graph
+                                    )
+
+            mobile_net.save_modules_nnp(
+                            OUTPUT_DIR + 'mn' + str(i), active_only=True,
+                            calc_latency=calc_latency,
+                            func_latency=estim_accum_by_graph
+                            )
+        if onnx:
+            mobile_net.convert_npp_to_onnx(OUTPUT_DIR)
+
+    #  4 **************************
+    if exp_nr == 4:
+        from nnabla_nas.module import static as smo
+
+        input1 = nn.Variable((1, 256, 32, 32))
+        input2 = nn.Variable((1, 384, 32, 32))
+        input3 = nn.Variable((1, 128, 32, 32))
+        input4 = nn.Variable((1, 768, 32, 32))
+        input5 = nn.Variable((1, 1280, 32, 32))
+        input6 = nn.Variable((1, 2048, 32, 32))
+        input7 = nn.Variable((1, 512, 32, 32))
+        input8 = nn.Variable((1, 192, 32, 32))
+        input9 = nn.Variable((1, 224, 32, 32))
+
+        static_input1 = smo.Input(value=input1)
+        static_input2 = smo.Input(value=input2)
+        static_input3 = smo.Input(value=input3)
+        static_input4 = smo.Input(value=input4)
+        static_input5 = smo.Input(value=input5)
+        static_input6 = smo.Input(value=input6)
+        static_input7 = smo.Input(value=input7)
+        static_input8 = smo.Input(value=input8)
+        static_input9 = smo.Input(value=input9)
+
+        myconv1 = smo.Conv(parents=[static_input1], in_channels=256,
+                           out_channels=128, kernel=(1, 1), pad=None, group=1)
+        myconv2 = smo.Conv(parents=[static_input2], in_channels=384,
+                           out_channels=128, kernel=(1, 1), pad=None, group=1)
+        myconv3 = smo.Conv(parents=[static_input3], in_channels=128,
+                           out_channels=256, kernel=(1, 1), pad=None, group=1)
+        myconv4 = smo.Conv(parents=[static_input4], in_channels=768,
+                           out_channels=256, kernel=(1, 1))
+        myconv5 = smo.Conv(parents=[static_input5], in_channels=1280,
+                           out_channels=256, kernel=(1, 1), pad=None, group=1)
+        myconv6 = smo.Conv(parents=[static_input6], in_channels=2048,
+                           out_channels=256, kernel=(1, 1), pad=None, group=1)
+        myconv7 = smo.Conv(parents=[static_input7], in_channels=512,
+                           out_channels=512, kernel=(3, 3), pad=(1, 1), group=1
+                           )
+        myconv8 = smo.Conv(parents=[static_input8], in_channels=192,
+                           out_channels=512, kernel=(7, 7), pad=(3, 3), group=1
+                           )
+        myconv9 = smo.Conv(parents=[static_input9], in_channels=224,
+                           out_channels=128, kernel=(5, 5), pad=(2, 2), group=1
+                           )
+
+        output1 = myconv1()
+        output2 = myconv2()
+        output3 = myconv3()
+        output4 = myconv4()
+        output5 = myconv5()
+        output6 = myconv6()
+        output7 = myconv7()
+        output8 = myconv8()
+        output9 = myconv9()
+
+        N = 10
+        for i in range(0, N):
+            mean_time = estim_fwd(output1)
+            print("1, ", mean_time)
+            mean_time = estim_fwd(output2)
+            print("2, ", mean_time)
+            mean_time = estim_fwd(output3)
+            print("3, ", mean_time)
+            mean_time = estim_fwd(output4)
+            print("4, ", mean_time)
+            mean_time = estim_fwd(output5)
+            print("5, ", mean_time)
+            mean_time = estim_fwd(output6)
+            print("6, ", mean_time)
+            mean_time = estim_fwd(output7)
+            print("7, ", mean_time)
+            mean_time = estim_fwd(output8)
+            print("8, ", mean_time)
+            mean_time = estim_fwd(output9)
+            print("9, ", mean_time)
+
+        N = 100
+        from nnabla_nas.utils.estimator.latency import LatencyGraphEstimator
+        for i in range(0, N):
+            estimation = LatencyGraphEstimator(n_run=100, ext_name='cpu')
+            latency = estimation.get_estimation(myconv1)
+            latency = estimation.get_estimation(myconv2)
+            latency = estimation.get_estimation(myconv3)
+            latency = estimation.get_estimation(myconv4)
+            latency = estimation.get_estimation(myconv5)
+            latency = estimation.get_estimation(myconv6)
+            latency = estimation.get_estimation(myconv7)
+            latency = estimation.get_estimation(myconv8)
+            latency = estimation.get_estimation(myconv9)
+
+            estimation = LatencyGraphEstimator(n_run=100, ext_name='cpu')
+            latency = estimation.get_estimation(myconv9)
+            latency = estimation.get_estimation(myconv8)
+            latency = estimation.get_estimation(myconv7)
+            latency = estimation.get_estimation(myconv6)
+            latency = estimation.get_estimation(myconv5)
+            latency = estimation.get_estimation(myconv4)
+            latency = estimation.get_estimation(myconv3)
+            latency = estimation.get_estimation(myconv2)
+            latency = estimation.get_estimation(myconv1)
+
+            estimation = LatencyGraphEstimator(n_run=100, ext_name='cpu')
+            latency = estimation.get_estimation(myconv6)
+            latency = estimation.get_estimation(myconv9)
+            latency = estimation.get_estimation(myconv1)
+            latency = estimation.get_estimation(myconv4)
+            latency = estimation.get_estimation(myconv8)
+            latency = estimation.get_estimation(myconv3)
+            latency = estimation.get_estimation(myconv5)
+            latency = estimation.get_estimation(myconv7)
+            latency = estimation.get_estimation(myconv2)
+
+            latency += 0  # to avoid lint/flake8 error
+
+    #  5 **************************
+    if exp_nr == 5:
+        from nnabla_nas.module import static as smo
+        from nnabla_nas.utils.estimator.latency import LatencyGraphEstimator
+        from numpy.random import permutation
+        import numpy as np
+
+        run_also_ours_at_the_end = True
+
+        N_conv = 50  # number of different convolutions tried
+        in_sizes = np.random.randint(low=1, high=1000, size=N_conv)
+        out_sizes = np.random.randint(low=1, high=600, size=N_conv)
+        kernel_sizes = np.random.randint(low=1, high=7, size=N_conv)
+        feat_sizes = np.random.randint(low=16, high=48, size=N_conv)
+
+        N = 100
+        for j in range(N):
+            estimation = LatencyGraphEstimator(n_run=100, ext_name='cpu')
+            print('****************** RUN ********************')
+            for i in permutation(N_conv):
+                input = nn.Variable((1, in_sizes[i],
+                                     feat_sizes[i], feat_sizes[i]))
+                static_input = smo.Input(value=input)
+                myconv = smo.Conv(parents=[static_input],
+                                  in_channels=in_sizes[i],
+                                  out_channels=out_sizes[i],
+                                  kernel=(kernel_sizes[i], kernel_sizes[i]),
+                                  pad=None, group=1
+                                  )
+                output = myconv()
+                latency = estimation.get_estimation(myconv)
+
+        latency += 0  # to avoid lint/flake8 error
+
+        if run_also_ours_at_the_end is True:
+            print('*********** NOW IT IS OUR TURN ***********')
+            for i in range(N_conv):
+                input = nn.Variable((1, in_sizes[i],
+                                    feat_sizes[i], feat_sizes[i]))
+                static_input = smo.Input(value=input)
+                myconv = smo.Conv(parents=[static_input],
+                                  in_channels=in_sizes[i],
+                                  out_channels=out_sizes[i],
+                                  kernel=(kernel_sizes[i], kernel_sizes[i]),
+                                  pad=None, group=1
+                                  )
+                output = myconv()
+                mean_time = estim_fwd(output, n_run=100) * 1000  # in ms
+                print('Our_Conv : 100 :', mean_time, ':',
+                      '[(1, ' + str(in_sizes[i]) + ', ' + str(feat_sizes[i]) +
+                      ', ' + str(feat_sizes[i]) + ')]',
+                      ':', out_sizes[i], ':', kernel_sizes[i]
+                      )
+
+    #  6 **************************
+    if exp_nr == 6:
+        import onnx
+        load_onnx = False
+
+        if len(sys.argv) > 2:
+            INPUT_DIR = sys.argv[2]
+        else:
+            INPUT_DIR = './logs/zoph/one_net/'
+
+        if len(sys.argv) > 3:
+            load_onnx = True
+
+        existing_networks = glob.glob(INPUT_DIR + '/*' + os.path.sep)
+        all_nets_latencies = dict.fromkeys([])
+        all_nets = dict.fromkeys([])
+        net_idx = 0
+        for network in existing_networks:
+            all_blocks = glob.glob(network + '**/*.acclat', recursive=True)
+            blocks = dict.fromkeys([])
+            block_idx = 0
+
+            this_net_accumulated_latency = 0.0
+            this_net_accumulated_latency_of_convs = 0.0
+            this_net_accumulated_latency_of_relus = 0.0
+            this_net_accumulated_latency_of_bns = 0.0
+            this_net_accumulated_latency_of_merges = 0.0
+            this_net_accumulated_latency_of_pools = 0.0
+            this_net_accumulated_latency_of_reshapes = 0.0
+            this_net_accumulated_latency_of_affines = 0.0
+            this_net_accumulated_latency_of_add2s = 0.0
+
+            for block_lat in all_blocks:
+                block = block_lat[:-7] + '.onnx'
+                print('.... READING .... -->  ' + block)
+
+                # Reading latency for each of the blocks of layers
+                with open(block_lat, 'r') as f:
+                    block_latency = float(f.read())
+
+                this_net_accumulated_latency += block_latency
+
+                # Layer-type-wise latencies tested
+                # for Zoph
+                # for Random Wired networks
+                # for mobilenet
+
+                layer_name = block.split('/')[-1].split('.')[-2]
+                if layer_name.find('bn') != -1:
+                    this_net_accumulated_latency_of_bns += block_latency
+                elif layer_name.find('batchnorm') != -1:
+                    this_net_accumulated_latency_of_bns += block_latency
+                elif layer_name.find('relu') != -1:
+                    this_net_accumulated_latency_of_relus += block_latency
+                elif layer_name.find('conv') != -1:
+                    this_net_accumulated_latency_of_convs += block_latency
+                elif layer_name.find('merg') != -1:
+                    this_net_accumulated_latency_of_merges += block_latency
+                elif layer_name.find('pool') != -1:
+                    this_net_accumulated_latency_of_pools += block_latency
+                elif layer_name.find('con') != -1:  # from concat
+                    this_net_accumulated_latency_of_merges += block_latency
+                elif layer_name.find('reshape') != -1:
+                    this_net_accumulated_latency_of_reshapes += block_latency
+                elif layer_name.find('linear') != -1:
+                    this_net_accumulated_latency_of_affines += block_latency
+                elif layer_name.find('add2') != -1:
+                    this_net_accumulated_latency_of_add2s += block_latency
+
+                this_block = dict.fromkeys([])
+                this_block['latency'] = block_latency
+
+                if load_onnx:
+                    # Interesting FIELDS in params.graph:
+                    # 'input', 'name', 'node', 'output'
+                    params = onnx.load(block)
+                    this_block['name'] = params.graph.name
+                    this_block['input'] = params.graph.input
+                    this_block['output'] = params.graph.output
+                    this_block['nodes'] = params.graph.node
+
+                blocks[block_idx] = this_block
+                block_idx += 1
+
+            net_realat_file = network[:-1] + '.realat'
+            with open(net_realat_file, 'r') as f:
+                this_net_real_latency = float(f.read())
+
+            net_acclat_file = network[:-1] + '.acclat'
+            with open(net_acclat_file, 'r') as f:
+                this_net_acc_latency = float(f.read())
+
+            this_net = dict.fromkeys([])
+            this_net['real_latency'] = this_net_real_latency
+            this_net['accum_latency_graph'] = this_net_acc_latency
+            this_net['accum_latency_module'] = this_net_accumulated_latency
+
+            if load_onnx:
+                net_file = network[:-1] + '.onnx'
+                print('xxxx READING xxxx -->  ' + net_file)
+                params = onnx.load(net_file)
+                this_net['name'] = params.graph.name
+                this_net['input'] = params.graph.input
+                this_net['output'] = params.graph.output
+                this_net['nodes'] = params.graph.node
+
+            all_nets_latencies[net_idx] = [
+                this_net_real_latency,
+                this_net_acc_latency,
+                this_net_accumulated_latency,
+                this_net_accumulated_latency_of_convs,
+                this_net_accumulated_latency_of_bns,
+                this_net_accumulated_latency_of_relus,
+                this_net_accumulated_latency_of_pools,
+                this_net_accumulated_latency_of_merges,
+                this_net_accumulated_latency_of_reshapes,
+                this_net_accumulated_latency_of_affines,
+                this_net_accumulated_latency_of_add2s,
+                ]
+
+            all_nets[net_idx] = this_net
+
+            net_idx += 1
+
+        # Compare accumulated latency to net latencies, do a plot:
+        print('LATENCY Results from ' + INPUT_DIR)
+        print('NETWORK, LAYER-WISE (by graph), ',
+              'LAYER-WISE (by module), of CONVs, of BNs, of RELUs, ',
+              'of POOLs, of MERGEs/CONCATs, of RESHAPEs, of AFFINEs, ',
+              'of ADD2 layers'
+              )
+        for i in range(len(all_nets_latencies)):
+            # print(all_nets_latencies[i])
+            print(['%7.3f' % val for val in all_nets_latencies[i]])
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        if len(sys.argv) > 2:
+            if (sys.argv[2] == 'O') \
+                    or (sys.argv[2] == 'LO') \
+                    or (sys.argv[2] == 'OL'):
+                onnx = True
+            else:
+                onnx = False
+            pass
+            if (sys.argv[2] == 'L') \
+                    or (sys.argv[2] == 'LO') \
+                    or (sys.argv[2] == 'OL'):
+                calc_latency = True
+            else:
+                calc_latency = False
+            pass
+            if (sys.argv[2] == 'L') \
+                    or (sys.argv[2] == 'LO') \
+                    or (sys.argv[2] == 'OL') \
+                    or (sys.argv[2] == 'O'):
+                if len(sys.argv) > 3:
+                    if len(sys.argv) > 4:
+                        calc_latency_and_onnx(int(sys.argv[1]),
+                                              calc_latency=calc_latency,
+                                              ext_name=sys.argv[3],
+                                              device_id=int(sys.argv[4]),
+                                              onnx=onnx
+                                              )
+                    else:
+                        calc_latency_and_onnx(int(sys.argv[1]),
+                                              calc_latency=calc_latency,
+                                              ext_name=sys.argv[3],
+                                              onnx=onnx
+                                              )
+                    pass
+                else:
+                    calc_latency_and_onnx(int(sys.argv[1]),
+                                          calc_latency=calc_latency,
+                                          onnx=onnx
+                                          )
+                pass
+            else:
+                if len(sys.argv) > 3:
+                    calc_latency_and_onnx(int(sys.argv[1]),
+                                          calc_latency=calc_latency,
+                                          ext_name=sys.argv[2],
+                                          device_id=int(sys.argv[3]),
+                                          onnx=onnx
+                                          )
+                else:
+                    calc_latency_and_onnx(int(sys.argv[1]),
+                                          calc_latency=calc_latency,
+                                          ext_name=sys.argv[2],
+                                          onnx=onnx
+                                          )
+                pass
+            pass
+        else:
+            calc_latency_and_onnx(int(sys.argv[1]), calc_latency=False)
+
+    else:
+        print('Usage: python calc_latency_export_onnx.py <id> ' +
+              '[L|LO|O|<path>] [<ext_name> [<device-id>]]')
+        print('If L is used, the estimation for latency will be calculated')
+        print('If O is used, the exporting to ONNX will be done')
+        print('If LO or OL is used, both the latency estimation and the ' +
+              'exporting to ONNX will be done')
+        print('Possible values for <ext_name>: cpu|cuda|cudnn. Default = cpu')
+        print('Possible values for <device_id>: 0..7 . Default = 0')
+        print('Possible values for <id>:')
+        print('# 10  : ZOPH - (one net) - create 1 instance of ZOPH network,' +
+              'save it and its modules, calc latency, export to ONNX')
+        print('# 11  : ZOPH - (many different nets)- sample a set of N ZOPH ' +
+              'networks, calculate latency, export all of them (whole net ' +
+              'and modules), convert to ONNX')
+        print('# 12  : ZOPH - (one net many times) Sample one ZOPH network, ' +
+              'calculate latency of this network N times')
+        print('# 20  : RANDOM WIRED - (one net) - create 1 instance of ' +
+              'random wired search space network, save it and its modules, ' +
+              'calc latency, convert to ONNX')
+        print('# 21  : RANDOM WIRED - (many different nets) - Sample a ' +
+              'set of N Random wired networks, calc latency, export them ' +
+              '(net and modules), convert to ONNX')
+        print('# 22  : RANDOM WIRED - (one net many times) Sample one ' +
+              'Random wired network, calculate latency of this network N ' +
+              'times, convert to ONNX')
+        print('# 31  : MOBILENET - (many different nets): Sample a set of ' +
+              'N mobilenet networks, calc latency, export them (net and ' +
+              'modules), convert to ONNX')
+        print('# 32  : MOBILENET - (one net many times): Sample one ' +
+              'mobilenet network, calculate latency N times, convert to ONNX')
+        print('# 4   : Sample several static convolutions (predefined), ' +
+              'calc latency on each of them many times')
+        print('# 5   : Sample several random-sized static convolutions. ' +
+              'Calc latency on each of them many times')
+        print('# 6 <path> [O] (please dont use <ext_name> or <device_id>): ' +
+              'from the given <path>, load all latencies, display them  -- ' +
+              'if flag O, load any existing ONNXs, put everything on dict. ' +
+              '(This was tested for zoph, random wired and mobilenet)')
+    pass

--- a/nnabla_nas/contrib/classification/base.py
+++ b/nnabla_nas/contrib/classification/base.py
@@ -18,16 +18,21 @@ from ..model import Model
 
 
 class ClassificationModel(Model):
-    r"""This class is a base `Model` for classification task. Your model should be based on this class."""
+    r"""This class is a base `Model` for classification task.
+        Your model should be based on this class."""
 
     def loss(self, outputs, targets, loss_weights=None):
-        r"""Return a loss computed from a list of outputs and a list of targets.
+        r"""Return loss computed from a list of outputs and list of targets.
 
         Args:
-            outputs (list of nn.Variable): A list of output variables computed from the model.
-            targets (list of nn.Variable): A list of target variables loaded from the data.
-            loss_weights (list of float, optional): A list specifying scalar coefficients to weight the loss
-                contributions of different model outputs. It is expected to have a 1:1 mapping to model outputs.
+            outputs (list of nn.Variable):
+                A list of output variables computed from the model.
+            targets (list of nn.Variable):
+                A list of target variables loaded from the data.
+            loss_weights (list of float, optional):
+                A list specifying scalar coefficients to weight the loss
+                contributions of different model outputs.
+                It is expected to have a 1:1 mapping to model outputs.
                 Defaults to None.
 
         Returns:
@@ -41,14 +46,17 @@ class ClassificationModel(Model):
     def metrics(self, outputs, targets):
         r"""Return a dictionary of metrics to monitor during training.
 
-        It is expected to have a 1:1 mapping between the model outputs and targets variables.
+        It is expected to have a 1:1 mapping between the
+        model outputs and targets variables.
 
         Args:
-            outputs (list of nn.Variable): A list of output variables computed from the model.
-            targets (list of nn.Variable): A list of target variables loaded from the data.
+            outputs (list of nn.Variable):
+                A list of output variables computed from the model.
+            targets (list of nn.Variable):
+                A list of target variables loaded from the data.
 
         Returns:
-            dict: A dictionary containing all metrics (nn.Variable) to monitor.
+            dict: A dictionary containing all metrics (nn.Variable) to monitor
                 E.g., {'error': nn.Variable((1,)), 'F1': nn.Variable((1,))}
         """
         assert len(targets) == 1

--- a/nnabla_nas/contrib/classification/misc.py
+++ b/nnabla_nas/contrib/classification/misc.py
@@ -47,15 +47,3 @@ class AuxiliaryHeadCIFAR(Mo.Module):
 
     def extra_repr(self):
         return f'channels={self._channels}, num_classes={self._num_classes}'
-
-
-class SepConv(Mo.DwConv):
-    def __init__(self, in_channels, out_channels, *args, **kwargs):
-        Mo.DwConv.__init__(self, in_channels=in_channels, *args, **kwargs)
-        self._out_channels = out_channels
-        self._conv_module_pw = Mo.Conv(self._in_channels, self._out_channels,
-                                       kernel=(1, 1), pad=None, group=1,
-                                       rng=self._rng, with_bias=False)
-
-    def call(self, input):
-        return self._conv_module_pw(Mo.DwConv.call(self, input))

--- a/nnabla_nas/contrib/model.py
+++ b/nnabla_nas/contrib/model.py
@@ -55,11 +55,14 @@ class Model(Mo.Module):
         r"""Return a loss computed from a list of outputs and a list of targets.
 
         Args:
-            outputs (list of nn.Variable): A list of output variables computed from the model.
-            targets (list of nn.Variable): A list of target variables loaded from the data.
-            loss_weights (list of float, optional): A list specifying scalar coefficients to weight the loss
-                contributions of different model outputs. It is expected to have a 1:1 mapping to model outputs.
-                Defaults to None.
+            outputs (list of nn.Variable): A list of output variables
+                 computed from the model.
+            targets (list of nn.Variable): A list of target variables
+                loaded from the data.
+            loss_weights (list of float, optional): A list specifying scalar
+                coefficients to weight the loss  contributions of different
+                model outputs. It is expected to have a 1:1 mapping to model
+                outputs. Defaults to None.
 
         Returns:
             nn.Variable: A scalar NNabla Variable represents the loss.
@@ -72,11 +75,14 @@ class Model(Mo.Module):
     def metrics(self, outputs, targets):
         r"""Return a dictionary of metrics to monitor during training.
 
-        It is expected to have a 1:1 mapping between the model outputs and targets.
+        It is expected to have a 1:1 mapping between the model outputs
+        and targets.
 
         Args:
-            outputs (list of nn.Variable): A list of output variables (nn.Variable) computed from the model.
-            targets (list of nn.Variable): A list of target variables (nn.Variable) loaded from the data.
+            outputs (list of nn.Variable): A list of output variables
+                                         (nn.Variable) computed from the model.
+            targets (list of nn.Variable): A list of target variables
+                                         (nn.Variable) loaded from the data.
 
         Returns:
             dict: A dictionary containing all metrics to monitor, e.g.,

--- a/nnabla_nas/module/__init__.py
+++ b/nnabla_nas/module/__init__.py
@@ -33,6 +33,7 @@ from .relu import ReLU6
 from .zero import Zero
 from .operation import Lambda
 from .mixedop import MixedOp
+from .add2 import Add2
 
 __all__ = [
     'Parameter',
@@ -48,7 +49,6 @@ __all__ = [
     'GlobalAvgPool',
     'Conv',
     'DwConv',
-    'SepConv',
     'BatchNormalization',
     'Linear',
     'ReLU',
@@ -56,5 +56,6 @@ __all__ = [
     'LeakyReLU',
     'Dropout',
     'Lambda',
-    'MixedOp'
+    'MixedOp',
+    'Add2',
 ]

--- a/nnabla_nas/module/add2.py
+++ b/nnabla_nas/module/add2.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nnabla.functions as F
+from .module import Module
+
+
+class Add2(Module):
+    r"""Adds two modules
+    Args:
+        inplace(bool): The output array is shared with the 1st input array
+        name (string): the name of this module
+    """
+
+    def __init__(self, inplace=False, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<add2 at {hex(id(self))}>'
+        self._inplace = inplace
+
+    def call(self, input1, input2):
+        return F.add2(input1, input2, inplace=self._inplace)

--- a/nnabla_nas/module/batchnorm.py
+++ b/nnabla_nas/module/batchnorm.py
@@ -26,9 +26,11 @@ class BatchNormalization(Module):
     Args:
         n_features (int): Number of dimentional features.
         n_dims (int): Number of dimensions.
-        axes (:obj:`tuple` of :obj:`int`): Mean and variance for each element in ``axes``
-            are calculated using elements on the rest axes. For example, if an input is 4 dimensions,
-            and ``axes`` is ``[1]``, batch mean is calculated as ``np.mean(inp.d, axis=(0, 2, 3), keepdims=True)``
+        axes (:obj:`tuple` of :obj:`int`): Mean and variance for each
+            element in ``axes`` are calculated using elements on the
+            rest axes. For example, if an input is 4 dimensions,
+            and ``axes`` is ``[1]``, batch mean is calculated as
+             ``np.mean(inp.d, axis=(0, 2, 3), keepdims=True)``
             (using numpy expression as an example).
         decay_rate (float, optional): Decay rate of running mean and
             variance. Defaults to 0.9.
@@ -47,6 +49,7 @@ class BatchNormalization(Module):
                     'beta': ConstantIntializer(0),
                     'gamma': np.ones(gamma_shape) * 2
                     }``.
+        name (string): the name of this module
 
     Returns:
         :class:`~nnabla.Variable`: N-D array.
@@ -58,7 +61,10 @@ class BatchNormalization(Module):
     """
 
     def __init__(self, n_features, n_dims, axes=[1], decay_rate=0.9, eps=1e-5,
-                 output_stat=False, fix_parameters=False, param_init=None):
+                 output_stat=False, fix_parameters=False, param_init=None,
+                 name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<batchnorm at {hex(id(self))}>'
 
         assert len(axes) == 1
 
@@ -78,13 +84,17 @@ class BatchNormalization(Module):
             self._gamma = nn.Variable.from_numpy_array(
                 gamma_init(shape_stat))
         else:
-            self._beta = Parameter(shape_stat, initializer=beta_init)
-            self._gamma = Parameter(shape_stat, initializer=gamma_init)
+            self._beta = Parameter(shape_stat, initializer=beta_init,
+                                   scope=self._scope_name)
+            self._gamma = Parameter(shape_stat, initializer=gamma_init,
+                                    scope=self._scope_name)
 
         self._mean = Parameter(shape_stat, need_grad=False,
-                               initializer=mean_init)
+                               initializer=mean_init,
+                               scope=self._scope_name)
         self._var = Parameter(shape_stat, need_grad=False,
-                              initializer=var_init)
+                              initializer=var_init,
+                              scope=self._scope_name)
         self._axes = axes
         self._decay_rate = decay_rate
         self._eps = eps

--- a/nnabla_nas/module/convolution.py
+++ b/nnabla_nas/module/convolution.py
@@ -63,12 +63,17 @@ class Conv(Module):
         channel_last(bool, optional): If True, the last dimension is
             considered as channel dimension, a.k.a NHWC order. Defaults to
             `False`.
+        name (string): the name of this module
     """
 
     def __init__(self, in_channels, out_channels, kernel, pad=None,
                  stride=None, dilation=None, group=1, w_init=None, b_init=None,
                  base_axis=1, fix_parameters=False, rng=None, with_bias=True,
-                 channel_last=False):
+                 channel_last=False, name=''):
+
+        Module.__init__(self, name=name)
+        self._scope_name = f'<convolution at {hex(id(self))}>'
+
         if w_init is None:
             w_init = UniformInitializer(
                 calc_uniform_lim_glorot(
@@ -88,9 +93,11 @@ class Conv(Module):
             if with_bias:
                 self._b = nn.Variable.from_numpy_array(b_init(b_shape))
         else:
-            self._W = Parameter(w_shape, initializer=w_init)
+            self._W = Parameter(w_shape, initializer=w_init,
+                                scope=self._scope_name)
             if with_bias:
-                self._b = Parameter(b_shape, initializer=b_init)
+                self._b = Parameter(b_shape, initializer=b_init,
+                                    scope=self._scope_name)
 
         self._base_axis = base_axis
         self._pad = pad
@@ -157,6 +164,7 @@ class DwConv(Module):
             Initializer.  Defaults to None.
         with_bias (bool, optional): Specify whether to include the bias term.
             Defaults to `True`.
+        name (string): the name of this module
 
     References:
         - F. Chollet: Chollet, Francois. "Xception: Deep Learning with
@@ -165,7 +173,11 @@ class DwConv(Module):
 
     def __init__(self, in_channels, kernel, pad=None, stride=None,
                  dilation=None, multiplier=1, w_init=None, b_init=None,
-                 base_axis=1, fix_parameters=False, rng=None, with_bias=True):
+                 base_axis=1, fix_parameters=False, rng=None, with_bias=True,
+                 name=''):
+
+        Module.__init__(self, name=name)
+        self._scope_name = f'<dwconvolution at {hex(id(self))}>'
         if w_init is None:
             w_init = UniformInitializer(
                 calc_uniform_lim_glorot(
@@ -181,15 +193,16 @@ class DwConv(Module):
         b_shape = (in_channels, )
 
         self._b = None
-
         if fix_parameters:
             self._W = nn.Variable.from_numpy_array(w_init(w_shape))
             if with_bias:
                 self._b = nn.Variable.from_numpy_array(b_init(b_shape))
         else:
-            self._W = Parameter(w_shape, initializer=w_init)
+            self._W = Parameter(w_shape, initializer=w_init,
+                                scope=self._scope_name)
             if with_bias:
-                self._b = Parameter(b_shape, initializer=b_init)
+                self._b = Parameter(b_shape, initializer=b_init,
+                                    scope=self._scope_name)
         self._pad = pad
         self._stride = stride
         self._dilation = dilation

--- a/nnabla_nas/module/dropout.py
+++ b/nnabla_nas/module/dropout.py
@@ -28,9 +28,12 @@ class Dropout(Module):
     Args:
         drop_prob (:obj:`int`, optional): The probability of an element to be
             zeroed. Defaults to 0.5.
+        name (string): the name of this module
     """
 
-    def __init__(self, drop_prob=0.5):
+    def __init__(self, drop_prob=0.5, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<dropout at {hex(id(self))}>'
         self._drop_prob = drop_prob
 
     def call(self, input):

--- a/nnabla_nas/module/identity.py
+++ b/nnabla_nas/module/identity.py
@@ -19,6 +19,9 @@ class Identity(Module):
     r"""Identity layer.
     A placeholder identity operator that is argument-insensitive.
     """
+    def __init__(self, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<identity at {hex(id(self))}>'
 
     def call(self, input):
         return input

--- a/nnabla_nas/module/linear.py
+++ b/nnabla_nas/module/linear.py
@@ -40,21 +40,26 @@ class Linear(Module):
             initialized with zeros if `with_bias` is `True`.
         rng (numpy.random.RandomState): Random generator for Initializer.
         with_bias (bool): Specify whether to include the bias term.
+        name (string): the name of this module
     """
 
     def __init__(self, in_features, out_features, base_axis=1, w_init=None,
-                 b_init=None, rng=None, bias=True):
+                 b_init=None, rng=None, bias=True, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<linear at {hex(id(self))}>'
 
         if w_init is None:
             w_init = UniformInitializer(
                 calc_uniform_lim_glorot(in_features, out_features), rng=rng)
-        self._W = Parameter((in_features, out_features), initializer=w_init)
+        self._W = Parameter((in_features, out_features), initializer=w_init,
+                            scope=self._scope_name)
         self._b = None
 
         if bias:
             if b_init is None:
                 b_init = ConstantInitializer()
-            self._b = Parameter((out_features, ), initializer=b_init)
+            self._b = Parameter((out_features, ), initializer=b_init,
+                                scope=self._scope_name)
 
         self._base_axis = base_axis
         self._in_features = in_features

--- a/nnabla_nas/module/merging.py
+++ b/nnabla_nas/module/merging.py
@@ -23,14 +23,19 @@ class Merging(Module):
     Merges a list of NNabla Variables.
 
     Args:
-        mode (str): The merging mode ('concat', 'add', 'mul'), where `concat` indicates that the
-            inputs will be concatenated, `add` means the element-wise addition, and `mul` means
-            the element-wise multiplication.
+        mode (str): The merging mode ('concat', 'add', 'mul'), where
+            `concat` indicates that the inputs will be concatenated,
+            `add` means the element-wise addition, and
+            `mul` means the element-wise multiplication.
         axis (int, optional): The axis for merging when 'concat' is used.
             Defaults to 1.
+        name (string): the name of this module
     """
 
-    def __init__(self, mode, axis=1):
+    def __init__(self, mode, axis=1, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<merging at {hex(id(self))}>'
+
         if mode not in ('concat', 'add', 'mul'):
             raise KeyError(f'{mode} is not supported.')
         self._mode = mode
@@ -39,11 +44,16 @@ class Merging(Module):
     def call(self, *input):
         if self._mode == 'concat' and len(input) > 1:
             return F.concatenate(*input, axis=self._axis)
-        if self._mode == 'add':
-            return sum(input)
+
         out = input[0]
-        for i in range(1, len(input)):
-            out = F.mul2(out, input[i])
+        if self._mode == 'add':
+            for i in range(1, len(input)):
+                out = F.add2(out, input[i])
+
+        if self._mode == 'mul':
+            for i in range(1, len(input)):
+                out = F.mul2(out, input[i])
+
         return out
 
     def extra_repr(self):

--- a/nnabla_nas/module/mixedop.py
+++ b/nnabla_nas/module/mixedop.py
@@ -36,9 +36,12 @@ class MixedOp(Module):
         alpha (Parameter, optional): The weights used to calculate the
             evaluation probabilities. Defaults to None.
         rng (numpy.random.RandomState): Random generator for random choice.
+        name (string): the name of this module
     """
 
-    def __init__(self, operators, mode='full', alpha=None, rng=None):
+    def __init__(self, operators, mode='full', alpha=None, rng=None, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<mixedop at {hex(id(self))}>'
         if mode not in ('max', 'sample', 'full'):
             raise ValueError(f'mode={mode} is not supported.')
 

--- a/nnabla_nas/module/operation.py
+++ b/nnabla_nas/module/operation.py
@@ -22,9 +22,12 @@ class Lambda(Module):
 
     Args:
         func (nnabla.functions): A NNabla funcion.
+        name (string): the name of this module
     """
 
-    def __init__(self, func):
+    def __init__(self, func, name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<{func.__name__} at {hex(id(self))}>'
         self._func = func
 
     def call(self, *args, **kargs):

--- a/nnabla_nas/module/parameter.py
+++ b/nnabla_nas/module/parameter.py
@@ -14,6 +14,7 @@
 
 import nnabla as nn
 import numpy as np
+from nnabla.parameter import set_parameter
 
 
 class Parameter(nn.Variable):
@@ -34,7 +35,15 @@ class Parameter(nn.Variable):
             initialize parameters from numpy array data. Defaults to None.
     """
 
-    def __new__(cls, shape, need_grad=True, initializer=None):
+    def __init__(self, *args, **kwargs):
+        super(Parameter, self).__init__()
+        if 'scope' in kwargs.keys():
+            with nn.parameter_scope(kwargs['scope']):
+                set_parameter(self.__repr__(), self)
+        else:
+            set_parameter(self.__repr__(), self)
+
+    def __new__(cls, shape, need_grad=True, initializer=None, scope=''):
         assert shape is not None
         obj = super().__new__(cls, shape, need_grad)
         if initializer is None:

--- a/nnabla_nas/module/pooling.py
+++ b/nnabla_nas/module/pooling.py
@@ -30,9 +30,13 @@ class MaxPool(Module):
             dimension. Defaults to ``(0,) * len(kernel)``.
         channel_last(bool): If True, the last dimension is considered as
             channel dimension, a.k.a NHWC order. Defaults to ``False``.
+        name (string): the name of this module
     """
 
-    def __init__(self, kernel, stride=None, pad=None, channel_last=False):
+    def __init__(self, kernel, stride=None, pad=None, channel_last=False,
+                 name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<maxpool at {hex(id(self))}>'
         self._kernel = kernel
         self._stride = stride
         self._pad = pad
@@ -63,9 +67,13 @@ class AvgPool(Module):
             dimension. Defaults to ``(0,) * len(kernel)``.
         channel_last(bool): If True, the last dimension is considered as
             channel dimension, a.k.a NHWC order. Defaults to ``False``.
+        name (string): the name of this module
     """
 
-    def __init__(self, kernel, stride=None, pad=None, channel_last=False):
+    def __init__(self, kernel, stride=None, pad=None, channel_last=False,
+                 name=''):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<avgpool at {hex(id(self))}>'
         self._kernel = kernel
         self._stride = stride
         self._pad = pad
@@ -87,7 +95,12 @@ class AvgPool(Module):
 class GlobalAvgPool(Module):
     r"""Global average pooling layer.
     It pools an averaged value from the whole image.
+    Args:
+        name (string): the name of this module
     """
+    def __init__(self, name=''):
+        self._name = name
+        self._scope_name = f'<globalavgpool at {hex(id(self))}>'
 
     def call(self, input):
         return F.global_average_pooling(input)

--- a/nnabla_nas/module/relu.py
+++ b/nnabla_nas/module/relu.py
@@ -24,10 +24,12 @@ class ReLU(Module):
     Args:
         inplace (bool, optional): can optionally do the operation in-place.
             Default: ``False``.
+        name (string): the name of this module
     """
 
-    def __init__(self, inplace=False):
-        Module.__init__(self)
+    def __init__(self, inplace=False, name=''):
+        self._scope_name = f'<relu at {hex(id(self))}>'
+        Module.__init__(self, name=name)
         self._inplace = inplace
 
     def call(self, input):
@@ -41,11 +43,14 @@ class ReLU6(Module):
     r"""ReLU6 layer.
     Capping ReLU activation to 6 is often observed to learn sparse features
     earlier.
+    Args:
+        name (string): the name of this module
 
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, name=''):
+        self._scope_name = f'<relu6 at {hex(id(self))}>'
+        Module.__init__(self, name=name)
 
     def call(self, input):
         return F.relu6(input)
@@ -60,9 +65,12 @@ class LeakyReLU(Module):
             :math:`\alpha` in the definition. Defaults to 0.1.
         inplace (bool, optional): can optionally do the operation in-place.
             Default: ``False``.
+        name (string): the name of this module
     """
 
-    def __init__(self, alpha=0.1, inplace=False):
+    def __init__(self, alpha=0.1, inplace=False, name=''):
+        self._scope_name = f'<leakyrelu at {hex(id(self))}>'
+        Module.__init__(self, name=name)
         self._alpha = alpha
         self._inplace = inplace
 

--- a/nnabla_nas/module/zero.py
+++ b/nnabla_nas/module/zero.py
@@ -26,7 +26,9 @@ class Zero(Module):
             dimensions. Defaults to (1, 1).
     """
 
-    def __init__(self, stride=(1, 1), *args, **kwargs):
+    def __init__(self, name='', stride=(1, 1)):
+        Module.__init__(self, name=name)
+        self._scope_name = f'<zero at {hex(id(self))}>'
         self._stride = stride
 
     def call(self, input):

--- a/nnabla_nas/utils/estimator/__init__.py
+++ b/nnabla_nas/utils/estimator/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .latency import LatencyEstimator
+from .latency import LatencyGraphEstimator
 from .memory import MemoryEstimator
 
-__all__ = ['MemoryEstimator', 'LatencyEstimator']
+__all__ = ['MemoryEstimator', 'LatencyEstimator', 'LatencyGraphEstimator']

--- a/nnabla_nas/utils/estimator/estimator.py
+++ b/nnabla_nas/utils/estimator/estimator.py
@@ -22,15 +22,14 @@ class Estimator(object):
             self._memo = dict()
         return self._memo
 
-    def get_estimation(self, module):
-        """Returns the estimation of the whole module."""
-        return sum(self.predict(m) for _, m in module.get_modules()
-                   if len(m.modules) == 0 and m.need_grad)
-
     def reset(self):
         """Clear cache."""
         self.memo.clear()
 
     def predict(self, module):
-        """Predicts the estimation for a module."""
+        """Predicts the estimation for a given module."""
+        raise NotImplementedError
+
+    def get_estimation(self, module):
+        """Obtains the estimation for a module and its children."""
         raise NotImplementedError

--- a/tests/contrib/zoph/test_avgpool3x3_module.py
+++ b/tests/contrib/zoph/test_avgpool3x3_module.py
@@ -20,11 +20,12 @@ from nnabla_nas.module import static as smo
 
 def test_avgpool3x3_module():
     shape = (10, 3, 32, 32)
+    n_channels = 20
     input = smo.Input(nn.Variable(shape))
 
-    pool = zoph.AveragePool3x3(parents=[input])
+    pool = zoph.AveragePool3x3(parents=[input], channels=n_channels)
 
-    assert pool.shape == (10, 3, 32, 32)
+    assert pool.input_shapes[0] == (10, 3, 32, 32)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/zoph/test_maxpool3x3_module.py
+++ b/tests/contrib/zoph/test_maxpool3x3_module.py
@@ -21,10 +21,11 @@ from nnabla_nas.module import static as smo
 def test_maxpool3x3_module():
     shape = (10, 3, 32, 32)
     input = smo.Input(nn.Variable(shape))
+    n_channels = 15
 
-    pool = zoph.MaxPool3x3(parents=[input])
+    pool = zoph.MaxPool3x3(parents=[input], channels=n_channels)
 
-    assert pool.shape == (10, 3, 32, 32)
+    assert pool.input_shapes[0] == (10, 3, 32, 32)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/zoph/test_sepconv_module.py
+++ b/tests/contrib/zoph/test_sepconv_module.py
@@ -25,7 +25,11 @@ def test_sepconv_module():
     conv = zoph.SepConv(parents=[input],
                         in_channels=3,
                         out_channels=64,
-                        kernel=(3, 3))
+                        kernel=(3, 3),
+                        pad=(0, 0),
+                        dilation=(1, 1),
+                        with_bias=False
+                        )
 
     assert conv.shape == (10, 64, 30, 30)
 

--- a/tests/contrib/zoph/test_sepconvbn_module.py
+++ b/tests/contrib/zoph/test_sepconvbn_module.py
@@ -25,16 +25,22 @@ def test_sepconvbn_module():
     conv = zoph.SepConvBN(parents=[input],
                           out_channels=64,
                           kernel=(3, 3),
-                          dilation=(1, 1))
+                          dilation=(1, 1),
+                          )
 
     assert conv.shape == (10, 64, 32, 32)
     mod_names = [mi.name for _, mi in conv.get_modules() if
                  isinstance(mi, smo.Module)]
     ex_mod_names = ['',
                     '/SepConv_1',
+                    '/SepConv_1/dwconv',
+                    '/SepConv_1/pwconv',
                     '/SepConv_2',
+                    '/SepConv_2/dwconv',
+                    '/SepConv_2/pwconv',
                     '/bn',
                     '/relu']
+
     for mni, emni in zip(mod_names, ex_mod_names):
         assert mni == emni
 

--- a/tests/contrib/zoph/test_zophblock.py
+++ b/tests/contrib/zoph/test_zophblock.py
@@ -32,8 +32,8 @@ def test_zophblock_module():
     out = zb()
     assert out.shape == (10, 64, 32, 32)
     assert zb.shape == (10, 64, 32, 32)
-    assert len(zb) == 13
-    cand = zb[4:-1]
+    assert len(zb) == 11
+    cand = zb[2:-1]
     for ci, cri in zip(cand, ZOPH_CANDIDATES):
         assert type(ci) == cri
 


### PR DESCRIPTION
This is the development branch for doing latency measurements on cpuand gpu, and creating an exporter to nnp and onnx:

New definition of the networks for zoph and random wired search space. Added functions to measure latency and to export to onnx for zoph and random wired and mobilenet search spaces. Bug fixing for calculation of latency. Two Latency estimators: LatencyEstimator(), a module-based latency estimator, LatencyGraphEstimator(), and a graph-based latency estimator. Both work for static as well as for dynamic modules. Central script that shows examples how to trigger the calculation of the latency and exporting to onnx for zoph, random wired and mobilenet search spaces. The latency estimation can be carried out on cpu or gpu. Another simpler script with an example for quick latency calculation. Updated Documentation- Code works with nnabla version 1.19.0.