### PR TITLE
add no_image_normalization param in executor when saving nnp

### DIFF
--- a/nnabla_nas/contrib/classification/darts/network.py
+++ b/nnabla_nas/contrib/classification/darts/network.py
@@ -178,10 +178,12 @@ class SearchNet(Model):
             save_dart_arch(self, path)
 
     def save_net_nnp(self, path, inp, out, calc_latency=False,
-                     func_real_latency=None, func_accum_latency=None):
+                     func_real_latency=None, func_accum_latency=None,
+                     save_params=None):
         super().save_net_nnp(path, inp, out, calc_latency=False,
                              func_real_latency=func_real_latency,
-                             func_accum_latency=func_accum_latency)
+                             func_accum_latency=func_accum_latency,
+                             save_params=save_params)
         if self._shared:
             # save the architectures
             save_dart_arch(self, path)

--- a/nnabla_nas/module/module.py
+++ b/nnabla_nas/module/module.py
@@ -280,7 +280,8 @@ class Module(object):
         return latencies, accum_lat
 
     def save_net_nnp(self, path, inp, out, calc_latency=False,
-                     func_real_latency=None, func_accum_latency=None):
+                     func_real_latency=None, func_accum_latency=None,
+                     save_params=None):
         """
             Saves whole net as one nnp
             Calc whole net (real) latency (using e.g.Nnabla's [Profiler])
@@ -318,6 +319,8 @@ class Module(object):
                                    'network': name_for_nnp,
                                    'data': ['x'],
                                    'output': ["y'"]}]}
+        if save_params and 'no_image_normalization' in save_params:
+            contents['executors'][0]['no_image_normalization'] = save_params['no_image_normalization']
 
         save(filename, contents, variable_batch_size=False)
 

--- a/nnabla_nas/runner/searcher/fairnas.py
+++ b/nnabla_nas/runner/searcher/fairnas.py
@@ -159,7 +159,8 @@ class FairNasSearcher(Searcher):
                 self.model.save_net_nnp(
                     self.args['output_path'],
                     self.placeholder['valid']['inputs'][0],
-                    self.placeholder['valid']['outputs'][0])
+                    self.placeholder['valid']['outputs'][0],
+                    save_params=self.args.get('save_params'))
             else:
                 self.model.save_parameters(
                     path=os.path.join(self.args['output_path'], 'weights.h5')

--- a/nnabla_nas/runner/searcher/search.py
+++ b/nnabla_nas/runner/searcher/search.py
@@ -65,7 +65,8 @@ class Searcher(Runner):
                 self.model.save_net_nnp(
                     self.args['output_path'],
                     self.placeholder['valid']['inputs'][0],
-                    self.placeholder['valid']['outputs'][0])
+                    self.placeholder['valid']['outputs'][0],
+                    save_params=self.args.get('save_params'))
             else:
                 self.model.save_parameters(
                     path=os.path.join(self.args['output_path'], 'arch.h5'),
@@ -85,7 +86,8 @@ class Searcher(Runner):
                 self.model.save_net_nnp(
                     self.args['output_path'],
                     self.placeholder['valid']['inputs'][0],
-                    self.placeholder['valid']['outputs'][0])
+                    self.placeholder['valid']['outputs'][0],
+                    save_params=self.args.get('save_params'))
             else:
                 self.model.save_parameters(
                     path=os.path.join(self.args['output_path'], 'weights.h5'),

--- a/nnabla_nas/runner/trainer/train.py
+++ b/nnabla_nas/runner/trainer/train.py
@@ -145,7 +145,8 @@ class Trainer(Runner):
                     self.model.save_net_nnp(
                         self.args['output_path'],
                         self.placeholder['valid']['inputs'][0],
-                        self.placeholder['valid']['outputs'][0])
+                        self.placeholder['valid']['outputs'][0],
+                        save_params=self.args.get('save_params'))
                 else:
                     path = os.path.join(self.args['output_path'], 'weights.h5')
                     self.model.save_parameters(path)


### PR DESCRIPTION
This PR supports that allows no_image_normalization parameters to be stored in nnp.
Here is the example:
```json
    "hparams": {
        "save_params": {
            "no_image_normalization": true
        }
    }
```

This PR needs https://github.com/sony/nnabla/pull/1066