### PR TITLE
get regulizers out of the optimizers dictionary.

### DIFF
--- a/examples/classification/mobilenet/cifar10_search_latency.json
+++ b/examples/classification/mobilenet/cifar10_search_latency.json
@@ -39,12 +39,12 @@
             "lr_scheduler": "CosineScheduler",
             "name": "Momentum",
             "lr": 0.1
-        },
-        "regularizer": {
-            "LatencyEstimator": {
-                "weight": 0.1,
-                "bound": 2.0
-            }
+        }
+    },
+    "regularizer": {
+        "LatencyEstimator": {
+            "weight": 0.1,
+            "bound": 2.0
         }
     },
     "hparams": {

--- a/examples/classification/mobilenet/imagenet_search_latency.json
+++ b/examples/classification/mobilenet/imagenet_search_latency.json
@@ -43,12 +43,12 @@
             "lr_scheduler": "CosineScheduler",
             "name": "Momentum",
             "lr": 0.05
-        },
-        "regularizer": {
-            "LatencyEstimator": {
-                "weight": 0.1,
-                "bound": 1.0
-            }
+        }
+    },
+    "regularizer": {
+        "LatencyEstimator": {
+            "weight": 0.1,
+            "bound": 1.0
         }
     },
     "hparams": {

--- a/examples/classification/pnas/cifar10_search_latency.json
+++ b/examples/classification/pnas/cifar10_search_latency.json
@@ -36,12 +36,12 @@
             "lr_scheduler": "CosineScheduler",
             "name": "Momentum",
             "lr": 0.025
-        },
-        "regularizer": {
-            "LatencyEstimator": {
-                "weight": 0.1,
-                "bound": 5.0
-            }
+        }
+    },
+    "regularizer": {
+        "LatencyEstimator": {
+            "weight": 0.1,
+            "bound": 5.0
         }
     },
     "hparams": {

--- a/nnabla_nas/runner/runner.py
+++ b/nnabla_nas/runner/runner.py
@@ -32,18 +32,21 @@ class Runner(ABC):
         model (`nnabla_nas.contrib.model.Model`): The search model used to
             search the architecture.
         optimizer (dict): This stores optimizers for both `train` and `valid`
-            graphs.
+            graphs. Must only store instances of `Optinmizer`
+        regularizer (dict): This stores regularizers such as the latency and memory
+            estimators
         dataloader (dict): This stores dataloaders for both `train` and `valid`
             graphs.
         args (Configuration): This stores all hyperparmeters used during
             training.
     """
 
-    def __init__(self, model, optimizer, dataloader, args):
+    def __init__(self, model, optimizer, regularizer, dataloader, args):
 
         self.model = model
         self.dataloader = dataloader
         self.optimizer = optimizer
+        self.regularizer = regularizer
         self.args = args
 
         # aditional argurments

--- a/nnabla_nas/runner/searcher/pnas.py
+++ b/nnabla_nas/runner/searcher/pnas.py
@@ -87,8 +87,7 @@ class ProxylessNasSearcher(Searcher):
                 self.monitor.update('loss/valid', loss * self.accum_valid, bz)
 
             # adding constraints
-            for k, v in self.optimizer.get('regularizer', {}).items():
-
+            for k, v in self.regularizer.items():
                 if isinstance(v, LatencyGraphEstimator):
                     #  when using LatencyGraphEstimator (by graph)
                     inp = [nn.Variable((1,)+si[1:]) for si in

--- a/nnabla_nas/utils/cli/cli.py
+++ b/nnabla_nas/utils/cli/cli.py
@@ -106,6 +106,7 @@ def main():
     runner.__dict__[hparams['algorithm']](
         model,
         optimizer=conf.optimizer,
+        regularizer=conf.regularizer,
         dataloader=conf.dataloader,
         args=conf.hparams
     ).run()


### PR DESCRIPTION
Regularizers (memory, latency, etc. ) were added to the optimizers dictionary. We separate them and add them to a new regularizer dictionary. This avoids some issues when saving checkpoints for auto-restart.