### PR TITLE
Add proper extra_repr to all OFA modules.

### DIFF
--- a/nnabla_nas/contrib/classification/ofa/elastic_modules.py
+++ b/nnabla_nas/contrib/classification/ofa/elastic_modules.py
@@ -24,7 +24,7 @@ from .modules import MBConvLayer, set_layer_from_config
 from .ofa_utils.common_tools import val2list, make_divisible
 from .ofa_modules.static_op import SEModule
 from .ofa_modules.dynamic_op import DynamicConv2d, DynamicBatchNorm2d, DynamicSeparableConv2d, DynamicSE
-from .modules import build_activation
+from .modules import build_activation, get_extra_repr
 
 
 def adjust_bn_according_to_idx(bn, idx):
@@ -95,13 +95,7 @@ class DynamicConvLayer(Mo.Module):
         return x
 
     def extra_repr(self):
-        return (f'in_channel_list={self._in_channel_list}, '
-                f'out_channel_list={self._out_channel_list}, '
-                f'kernel={self._kernel}, '
-                f'stride={self._stride}, '
-                f'dilation={self._dilation}, '
-                f'use_bn={self._use_bn}, '
-                f'act_func={self._act_func}')
+        return get_extra_repr(self)
 
 
 class DynamicMBConvLayer(Mo.Module):
@@ -182,13 +176,7 @@ class DynamicMBConvLayer(Mo.Module):
         return x
 
     def extra_repr(self):
-        return (f'in_channel_list={self._in_feature_list}, '
-                f'out_channel_list={self._out_channel_list}, '
-                f'kernel_size_list={self._kernel_size_list}, '
-                f'expand_ratio_list={self._expand_ratio_list}, '
-                f'stride={self._strride}, '
-                f'act_func={self._act_func}, '
-                f'use_se={self._use_se} ')
+        return get_extra_repr(self)
 
     def re_organize_middle_weights(self, expand_ratio_stage=0):
         importance = np.sum(np.abs(self.point_linear.conv.conv._W.d), axis=(0, 2, 3))

--- a/nnabla_nas/contrib/classification/ofa/modules.py
+++ b/nnabla_nas/contrib/classification/ofa/modules.py
@@ -105,6 +105,21 @@ def get_bn_param(net):
             }
 
 
+def get_extra_repr(cur_obj):
+    repr = ""
+    for var in vars(cur_obj):
+        # Skip this field just for a better printout
+        if var == '_modules':
+            continue
+
+        var_value = getattr(cur_obj, var)
+        repr += f'{var}='
+        repr += f'{var_value}, '
+
+    repr += ')'
+    return repr
+
+
 class ResidualBlock(Mo.Module):
     r"""ResidualBlock layer.
 
@@ -197,16 +212,7 @@ class ConvLayer(Mo.Sequential):
         return ConvLayer(**config)
 
     def extra_repr(self):
-        return (f'in_channels={self._in_channels}, '
-                f'out_channels={self._out_channels}, '
-                f'kernel={self._kernel}, '
-                f'stride={self._stride}, '
-                f'dilation={self._dilation}, '
-                f'group={self._group}, '
-                f'with_bias={self._with_bias}, '
-                f'use_bn={self._use_bn}, '
-                f'act_func={self._act_func}, '
-                f'name={self._name}')
+        return get_extra_repr(self)
 
 
 class MBConvLayer(Mo.Module):
@@ -290,15 +296,7 @@ class MBConvLayer(Mo.Module):
         return MBConvLayer(**config)
 
     def extra_repr(self):
-        return (f'in_channels={self._in_channels}, '
-                f'out_channels={self._out_channels}, '
-                f'kernel={self._kernel}, '
-                f'stride={self._stride}, '
-                f'expand_ratio={self._expand_ratio}, '
-                f'mid_channels={self._mid_channels}, '
-                f'act_func={self._act_func}, '
-                f'use_se={self._use_se}, '
-                f'group={self._group} ')
+        return get_extra_repr(self)
 
 
 class LinearLayer(Mo.Sequential):
@@ -330,11 +328,7 @@ class LinearLayer(Mo.Sequential):
         return LinearLayer(**config)
 
     def extra_repr(self):
-        return (f'in_channels={self._in_channels}, '
-                f'out_channels={self._out_channels}, '
-                f'bias={self._bias}, '
-                f'drop_rate={self._drop_rate}, '
-                f'name={self._name} ')
+        return get_extra_repr(self)
 
 
 def build_activation(act_func, inplace=False):

--- a/nnabla_nas/contrib/classification/ofa/network.py
+++ b/nnabla_nas/contrib/classification/ofa/network.py
@@ -413,12 +413,14 @@ class SearchNet(MyNetwork):
         }
 
     def extra_repr(self):
-        return (f'num_classes={self._num_classes}, '
-                f'drop_rate={self._drop_rate}, '
-                f'width_mult={self._width_mult}, '
-                f'ks_list={self._ks_list}, '
-                f'expand_ratio_list={self._expand_ratio_list}, '
-                f'depth_list={self._depth_list}')
+        repr = ""
+        for var in vars(self):
+            var_value = getattr(self, var)
+            repr += f'{var}='
+            repr += f'{var_value}, '
+
+        repr += ')'
+        return repr
 
     def save_parameters(self, path=None, params=None, grad_only=False):
         super().save_parameters(path, params=params, grad_only=grad_only)


### PR DESCRIPTION
By adopting this PR, the following issue will be solved.

## How to reproduce

Call print() will cause this error.

```python
# Add print() to nnabla_nas/utils/cli/cli.py
    model = algorithm.SearchNet(**attributes) if hparams['search'] else \
        algorithm.TrainNet(**attributes)
    print(model) # Adding this line
```
Execute this command.

```bash
python main.py \
               -f examples/classification/ofa/ofa_imagenet_search_fullnet.json \
               -a OFASearcher \
               -o log/classification/ofa/imagenet/search/K7_E6_D4/
```

## Error message

```
Traceback (most recent call last):
  File "main.py", line 20, in <module>
    main()
  File "nnabla-nas/nnabla_nas/utils/cli/cli.py", line 102, in main
    print(model)
  File "nnabla-nas/nnabla_nas/module/module.py", line 592, in __str__
    m_repr = str(module).split('\n')
  File "nnabla-nas/nnabla_nas/module/module.py", line 589, in __str__
    main_str = f'{self.__class__.__name__}(' + self.extra_repr()
  File "nnabla-nas/nnabla_nas/contrib/classification/ofa/modules.py", line 200, in extra_repr
    return (f'in_channels={self._in_channels}, '
  File "nnabla-nas/nnabla_nas/module/module.py", line 104, in __getattr__
    return object.__getattr__(self, name)
AttributeError: type object 'object' has no attribute '__getattr__'
```

Other search space in `examples/jobs.sh` works well.