### PR TITLE
Support nnabla.no_grad etc.

### DIFF
--- a/nnabla_nas/module/module.py
+++ b/nnabla_nas/module/module.py
@@ -62,7 +62,7 @@ class Module(object):
     @training.setter
     def training(self, mode):
         self.__dict__['_training'] = mode
-        for m in self.get_modules():
+        for _, m in self.modules.items():
             m.training = mode
 
     @property
@@ -75,7 +75,7 @@ class Module(object):
     @need_grad.setter
     def need_grad(self, mode):
         self.__dict__['_need_grad'] = mode
-        for m in self.get_modules():
+        for _, m in self.modules.items():
             m.need_grad = mode
 
     @property

--- a/nnabla_nas/module/module.py
+++ b/nnabla_nas/module/module.py
@@ -115,7 +115,7 @@ class Module(object):
             need_grad_state = self._get_need_grad_state()
             p = self.parameters[name]
             if not need_grad_state and p.need_grad:
-                return p.get_unlinked_variable(need_grad=need_grad_state).apply(name=p.name)
+                return p.get_unlinked_variable(need_grad=need_grad_state)
             return p
         return object.__getattr__(self, name)
 

--- a/nnabla_nas/module/module.py
+++ b/nnabla_nas/module/module.py
@@ -62,6 +62,8 @@ class Module(object):
     @training.setter
     def training(self, mode):
         self.__dict__['_training'] = mode
+        for m in self.get_modules():
+            m.training = mode
 
     @property
     def need_grad(self):
@@ -73,6 +75,8 @@ class Module(object):
     @need_grad.setter
     def need_grad(self, mode):
         self.__dict__['_need_grad'] = mode
+        for m in self.get_modules():
+            m.need_grad = mode
 
     @property
     def is_active(self):
@@ -96,11 +100,23 @@ class Module(object):
     def input_shapes(self, v):
         setattr(self, '_input_shapes', v)
 
+    def _get_need_grad_state(self):
+        from nnabla import parameter
+        # TODO: Ideally want to have get_current_no_grad_state() in parameter module?
+        no_grad = parameter.current_no_grad
+        if no_grad:
+            return False
+        return self.need_grad
+
     def __getattr__(self, name):
         if name in self.modules:
             return self.modules[name]
         if name in self.parameters:
-            return self.parameters[name]
+            need_grad_state = self._get_need_grad_state()
+            p = self.parameters[name]
+            if not need_grad_state and p.need_grad:
+                return p.get_unlinked_variable(need_grad=need_grad_state).apply(name=p.name)
+            return p
         return object.__getattr__(self, name)
 
     def __setattr__(self, name, value):

--- a/nnabla_nas/runner/searcher/ofa.py
+++ b/nnabla_nas/runner/searcher/ofa.py
@@ -257,8 +257,8 @@ class OFASearcher(Searcher):
                     soft_logits = self.teacher_model(*inputs)
                     soft_logits = soft_logits if isinstance(soft_logits, (tuple, list)) else (soft_logits,)
                     p['soft_logits'] = [x.apply(need_grad=False) for x in soft_logits]
-                    kd_loss = self.model.kd_loss(
-                        p['outputs'], p['soft_logits'], p['targets'], self.args['loss_weights'])
+                kd_loss = self.model.kd_loss(
+                    p['outputs'], p['soft_logits'], p['targets'], self.args['loss_weights'])
 
             # loss function
             if self.args['lambda_kd'] > 0:


### PR DESCRIPTION
This PR includes what I modified during a huddle session with @yuikosakuma1 to enable building a computation graph that doesn't require gradient computation in order to save memory for the intermediate variables. It is never tested but just committed at the end of the session. The changes include:

* Create computation graph with need_grad=False when `nnabla.no_grad()` is used or `self.need_grad=False` in Module class.
* Recursively change the following states in Module class: need_grad & training (I suppose this is the expected behavior. Otherwise, it'll ignore the specified states in submodules, which must be unexpected by users. For example, Dropout is applied even when you specify `model.training = False` where we suppose `model` is a top-level module containing Dropout class as a submodule. **EDIT**: I noticed that `Module.apply` recursively modifies any attribute, but I'd suggest we modify attributes recursively even in the property setter methods. That should avoid confusing users.