### PR TITLE
Fix parameters not being  inherited.

### DIFF
--- a/nnabla_nas/contrib/classification/random_wired/random_wired.py
+++ b/nnabla_nas/contrib/classification/random_wired/random_wired.py
@@ -19,6 +19,7 @@ import networkx as nx
 import nnabla as nn
 import numpy as np
 
+from nnabla_nas.contrib.classification.base import ClassificationModel as Model
 from nnabla_nas.module import static as smo
 
 
@@ -349,7 +350,7 @@ RANDOM_CANDIDATES = [RandomModule,
                      AvgPool2x2]
 
 
-class TrainNet(smo.Graph):
+class TrainNet(Model, smo.Graph):
     """
     A randomly wired DNN that uses the Watts-Strogatz process to generate
     random DNN architectures. Please refer to [Xie et. al]

--- a/nnabla_nas/contrib/classification/zoph/zoph.py
+++ b/nnabla_nas/contrib/classification/zoph/zoph.py
@@ -18,6 +18,8 @@ import nnabla as nn
 import nnabla.functions as F
 import numpy as np
 
+from nnabla_nas.contrib.classification.base import ClassificationModel as Model
+
 from ....module import static as smo
 from ....module.parameter import Parameter
 
@@ -485,7 +487,7 @@ class ZophCell(smo.Graph):
                                 parents=cell_modules, mode='concat'))
 
 
-class SearchNet(smo.Graph):
+class SearchNet(Model, smo.Graph):
     """
     A search space as defined in [Bender et. al]
 


### PR DESCRIPTION
Scripts in examples/classification were not running due to some parameters not being inherited.