### PR TITLE
Fix formating : missing whitespace after keyword

### DIFF
--- a/nnabla_nas/contrib/classification/ofa/networks/ofa_mbv3.py
+++ b/nnabla_nas/contrib/classification/ofa/networks/ofa_mbv3.py
@@ -80,7 +80,7 @@ def genotype2subnetlist(op_candidates, genotype):
             depth_list.append(d + 1)
         else:
             d += 1
-    assert([d > 1 for d in depth_list])
+    assert ([d > 1 for d in depth_list])
     return ks_list, expand_ratio_list, depth_list
 
 
@@ -255,7 +255,7 @@ class OFAMbv3Net(ClassificationModel):
         return self.classifier(x)
 
     def set_valid_arch(self, genotype):
-        assert(len(genotype) == 20)
+        assert (len(genotype) == 20)
         ks_list, expand_ratio_list, depth_list =\
             genotype2subnetlist(self._op_candidates, genotype)
         self.set_active_subnet(ks_list, expand_ratio_list, depth_list)
@@ -531,7 +531,7 @@ class TrainNet(OFAMbv3Net):
             op_candidates=op_candidates, depth_candidates=depth_candidates, weights=weights)
 
         if genotype is not None:
-            assert(len(genotype) == 20)
+            assert (len(genotype) == 20)
             ks_list, expand_ratio_list, depth_list = genotype2subnetlist(
                 op_candidates, genotype)
             self.set_active_subnet(ks_list, expand_ratio_list, depth_list)

--- a/nnabla_nas/contrib/classification/ofa/networks/ofa_xception.py
+++ b/nnabla_nas/contrib/classification/ofa/networks/ofa_xception.py
@@ -86,7 +86,7 @@ class ProcessGenotype:
         expand_ratio_list = [cls.CANDIDATES[subnet]['expand_ratio'] for subnet in subnet_list]
         depth_list = [cls.CANDIDATES[subnet]['depth'] for subnet in subnet_list]
 
-        assert([d >= 1 for d in depth_list])
+        assert ([d >= 1 for d in depth_list])
         return ks_list, expand_ratio_list, depth_list
 
 
@@ -248,7 +248,7 @@ class OFAXceptionNet(ClassificationModel):
         return self.classifier(x)
 
     def set_valid_arch(self, genotype):
-        assert(len(genotype) == OFAXceptionNet.NUM_MIDDLE_BLOCKS)
+        assert (len(genotype) == OFAXceptionNet.NUM_MIDDLE_BLOCKS)
         ks_list, expand_ratio_list, depth_list =\
             ProcessGenotype.get_subnet_arch(self._op_candidates, genotype)
         self.set_active_subnet(ks_list, expand_ratio_list, depth_list)
@@ -497,7 +497,7 @@ class TrainNet(OFAXceptionNet):
             base_stage_width=base_stage_width, op_candidates=op_candidates, weights=weights)
 
         if genotype is not None:
-            assert(len(genotype) == OFAXceptionNet.NUM_MIDDLE_BLOCKS)
+            assert (len(genotype) == OFAXceptionNet.NUM_MIDDLE_BLOCKS)
             ks_list, expand_ratio_list, depth_list = ProcessGenotype.get_subnet_arch(op_candidates, genotype)
             self.set_active_subnet(ks_list, expand_ratio_list, depth_list)
 

--- a/nnabla_nas/utils/estimator/estimator.py
+++ b/nnabla_nas/utils/estimator/estimator.py
@@ -26,7 +26,7 @@ class Estimator(object):
         """Returns the estimation of the whole module."""
         return sum(self.predict(m) for _, m in module.get_modules()
                    if len(m.modules) == 0 and m.need_grad
-                   and (not(hasattr(m, 'is_active')) or m.is_active))
+                   and (not (hasattr(m, 'is_active')) or m.is_active))
 
     def reset(self):
         """Clear cache."""


### PR DESCRIPTION
CI did not pass after release of flake8 5.0
Flake8 returned several : E275 missing whitespace after keyword

This pull request fixes the formatting.
