### PR TITLE
f-string compatibility with Python version < 3.8

### DIFF
--- a/nnabla_nas/runner/runner.py
+++ b/nnabla_nas/runner/runner.py
@@ -106,7 +106,7 @@ class Runner(ABC):
             key (str, optional): Type of graph. Defaults to 'train'.
         """
         if key not in ('train', 'valid', 'warmup'):
-            raise ValueError(f'{key = } is not allowed')
+            raise ValueError(f'key = {key} is not allowed')
 
         if key in ('train', 'warmup'):
             key = 'train'


### PR DESCRIPTION
Avoid the use of `print(f" {variable = } ...")` syntax that is not supported by Python < 3.8.