### PR TITLE
Fix mismatching order of params of AvgPool

### DIFF
--- a/nnabla_nas/contrib/classification/darts/modules.py
+++ b/nnabla_nas/contrib/classification/darts/modules.py
@@ -23,8 +23,8 @@ CANDIDATES = OrderedDict([
     ('dil_conv_5x5', lambda c, s: DDSConv(c, c, (5, 5), (4, 4), (s, s))),
     ('sep_conv_3x3', lambda c, s: SepConv(c, c, (3, 3), (1, 1), (s, s))),
     ('sep_conv_5x5', lambda c, s: SepConv(c, c, (5, 5), (2, 2), (s, s))),
-    ('max_pool_3x3', lambda c, s: Mo.MaxPool((3, 3), (s, s), (1, 1))),
-    ('avg_pool_3x3', lambda c, s: Mo.AvgPool((3, 3), (s, s), (1, 1))),
+    ('max_pool_3x3', lambda c, s: Mo.MaxPool((3, 3), stride=(s, s), pad=(1, 1))),
+    ('avg_pool_3x3', lambda c, s: Mo.AvgPool((3, 3), stride=(s, s), pad=(1, 1))),
     ('skip_connect', lambda c, s: FactorizedReduce(c, c) if s > 1
      else Mo.Identity()),
     ('none', lambda c, s: Mo.Zero((s, s)))

--- a/tests/contrib/darts/__init__.py
+++ b/tests/contrib/darts/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/contrib/darts/test_darts.py
+++ b/tests/contrib/darts/test_darts.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nnabla as nn
+
+from nnabla_nas.contrib.classification.darts import SearchNet
+
+
+def test_darts():
+    net = SearchNet(in_channels=3, init_channels=16, num_cells=8, num_classes=1000)
+    input = nn.Variable((1, 3, 32, 32))
+
+    assert net(input).shape == (1, net._num_classes)
+    assert str(net)


### PR DESCRIPTION
Fix mismatching order of params of `class AvgPool`.

Related issue: #45
