### PR TITLE
Fix wrong working directory for OFAResnet50 and OFAXception search spaces

### DIFF
--- a/nnabla_nas/contrib/classification/ofa/networks/ofa_resnet50.py
+++ b/nnabla_nas/contrib/classification/ofa/networks/ofa_resnet50.py
@@ -14,6 +14,7 @@
 
 from collections import OrderedDict
 import random
+import os
 
 import nnabla as nn
 import nnabla.functions as F
@@ -29,6 +30,7 @@ from ....common.ofa.utils.common_tools import init_models
 from ....common.ofa.elastic_nn.modules.dynamic_layers import DynamicConvLayer, DynamicLinearLayer
 from ....common.ofa.elastic_nn.modules.dynamic_layers import DynamicBottleneckResidualBlock
 from ....common.ofa.elastic_nn.modules.dynamic_op import DynamicBatchNorm
+from hydra import utils
 
 
 class OFAResNet50(ClassificationModel):

--- a/nnabla_nas/contrib/classification/ofa/networks/ofa_resnet50.py
+++ b/nnabla_nas/contrib/classification/ofa/networks/ofa_resnet50.py
@@ -317,7 +317,9 @@ class OFAResNet50(ClassificationModel):
 
     def load_parameters(self, path, raise_if_missing=False):
         with nn.parameter_scope('', OrderedDict()):
-            nn.load_parameters(path)
+            # adjust path because hydra changes the working directory
+            load_path = os.path.realpath(os.path.join(utils.get_original_cwd(), path))
+            nn.load_parameters(load_path)
             params = nn.get_parameters(grad_only=False)
         self.set_parameters(params, raise_if_missing=raise_if_missing)
 

--- a/nnabla_nas/contrib/classification/ofa/networks/ofa_xception.py
+++ b/nnabla_nas/contrib/classification/ofa/networks/ofa_xception.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import random
+import os
 from collections import OrderedDict
 
 import nnabla as nn
@@ -27,6 +28,7 @@ from ....common.ofa.elastic_nn.modules.dynamic_op import DynamicBatchNorm
 from ....common.ofa.utils.common_tools import val2list, make_divisible
 from ....common.ofa.utils.common_tools import cross_entropy_loss_with_label_smoothing
 from ....common.ofa.utils.common_tools import cross_entropy_loss_with_soft_target
+from hydra import utils
 
 
 class ProcessGenotype:

--- a/nnabla_nas/contrib/classification/ofa/networks/ofa_xception.py
+++ b/nnabla_nas/contrib/classification/ofa/networks/ofa_xception.py
@@ -371,7 +371,9 @@ class OFAXceptionNet(ClassificationModel):
 
     def load_parameters(self, path, raise_if_missing=False):
         with nn.parameter_scope('', OrderedDict()):
-            nn.load_parameters(path)
+            # adjust path because hydra changes the working directory
+            load_path = os.path.realpath(os.path.join(utils.get_original_cwd(), path))
+            nn.load_parameters(load_path)
             params = nn.get_parameters(grad_only=False)
         self.set_parameters(params, raise_if_missing=raise_if_missing)
 


### PR DESCRIPTION
Adjust the working directories when reading the pretrained files since Hydra will change the working directories.