### PR TITLE
Fix imagenet datapath

### DIFF
--- a/conf/dataloader/classification/imagenet.yaml
+++ b/conf/dataloader/classification/imagenet.yaml
@@ -1,7 +1,7 @@
 
 imagenet:
   datapath: /disk1/data/ILSVRC-2012/
-  train_path: img_train/
+  train_path: train/
   train_file: train_label
-  valid_path: img_val/
+  valid_path: val/
   valid_file: val_label

--- a/conf/dataloader/classification/imagenet_ofa.yaml
+++ b/conf/dataloader/classification/imagenet_ofa.yaml
@@ -3,7 +3,7 @@ imagenet:
   augment_valid: False
   colortwist: True
   datapath: /disk1/data/ILSVRC-2012/
-  train_path: img_train/
+  train_path: train/
   train_file: train_label
-  valid_path: img_val/
+  valid_path: val/
   valid_file: val_label


### PR DESCRIPTION
The directory name in dataset config is not consistent with that created by nnabla-example instruction (https://github.com/sony/nnabla-examples/tree/master/image-classification/imagenet#:~:text=Preparing%20ImageNet%20dataset)
For instance, the directory name is train/ and val/ by running the script in [the link](https://github.com/sony/nnabla-examples/tree/master/image-classification/imagenet#:~:text=Preparing%20ImageNet%20dataset), however, in NNablaNAS, the directory name is img_train and img_val.