### PR TITLE
Fix bz parameter for schedulers 

### DIFF
--- a/nnabla_nas/utils/cli/args.py
+++ b/nnabla_nas/utils/cli/args.py
@@ -86,7 +86,7 @@ class Configuration(object):
                         lr = args['alpha']  # for adam
 
                     bz = conf['hparams']['batch_size_train' if name != 'valid' else 'batch_size_valid']  \
-                        / conf['args']['comm'].n_procs
+                        // conf['args']['comm'].n_procs
                     epoch = conf['hparams']['epoch'] if 'train' in name else conf['hparams']['warmup']
                     max_iter = epoch * len(self.dataloader['valid'if name == 'valid' else 'train']) // bz
 

--- a/nnabla_nas/utils/cli/args.py
+++ b/nnabla_nas/utils/cli/args.py
@@ -85,7 +85,8 @@ class Configuration(object):
                     except KeyError:
                         lr = args['alpha']  # for adam
 
-                    bz = conf['hparams']['batch_size_train' if name != 'valid' else 'batch_size_valid']
+                    bz = conf['hparams']['batch_size_train' if name != 'valid' else 'batch_size_valid']  \
+                        / conf['args']['comm'].n_procs
                     epoch = conf['hparams']['epoch'] if 'train' in name else conf['hparams']['warmup']
                     max_iter = epoch * len(self.dataloader['valid'if name == 'valid' else 'train']) // bz
 


### PR DESCRIPTION
Bug due to change for using global batch size.

`bz` parameter, that is used to calculate the number of iterations, should be the local batch size.
Because of this bug, LR scheduler did not calculate LR properly. (Estimates `batch_iters` smaller than the actual)