### PR TITLE
Use scikit-learn package instead of sklearn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,9 @@ jobs:
   
 
   test:
-    runs-on: ubuntu-latest
+    # There is no python3.6 package for ubuntu-latest(22.04),
+    # so we use 20.04 environment.
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx_rtd_theme
 sphinxcontrib-bibtex
 nnabla
 hydra-core
-sklearn
+scikit-learn
 more-itertools
 networkx
 tensorboard

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     mypy
     networkx
     nnabla
-    sklearn
+    scikit-learn
     tensorboard
     tqdm
     hydra-core


### PR DESCRIPTION
sklearn pakcage on PyPI is deprecating now, so we will migrate to use scikit-learn.

As references:
* https://pypi.org/project/sklearn/
* https://pypi.org/project/scikit-learn/

Also updated runtime environment because python3.6 environment is not available on ubuntu-latest.