### PR TITLE
Add .readthedocs.yaml v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Configuration file v2 (.readthedoc.yaml) is going to be mandatory on ReadTheDocs, here is the source: https://blog.readthedocs.com/migrate-configuration-v2/

This PR is the corresponding change to create documents by nnabla-nas/docs.