### PR TITLE
Fix readthedocs dependency for version switch issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 sphinx
-sphinx_rtd_theme
+sphinx_rtd_theme>=1.2
 sphinxcontrib-bibtex
+jinja2>3.1.0
 nnabla
 hydra-core
 scikit-learn


### PR DESCRIPTION
This PR supports readthedocs configuration file format v2.

